### PR TITLE
ci: don't compress the artifact twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,11 @@ jobs:
         run: sudo apt install gettext
 
       - name: Build the extension
-        run: just pack
+        run: just build
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: rounded-window-corners@fxgn.shell-extension
-          path: rounded-window-corners@fxgn.shell-extension.zip
+          path: _build/
+          compression-level: 9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rounded-window-corners@fxgn.shell-extension.zip
+          name: rounded-window-corners@fxgn.shell-extension
           path: rounded-window-corners@fxgn.shell-extension.zip


### PR DESCRIPTION
- Right now, downloading the artifact gives you this: [rounded-window-corners@fxgn.shell-extension.zip.zip](mailto:rounded-window-corners@fxgn.shell-extension.zip.zip).
    Fix in [016ca30](https://github.com/M1n-74316D65/rounded-window-corners/commit/016ca30ea0eaa3975b4ead36a8874f898390002e).

- The actions/upload-artifact@v4 always creates a zip, so there's a zip within a zip.
    Fix in [523d0c9](https://github.com/M1n-74316D65/rounded-window-corners/commit/523d0c95e146a15a41bf6efd8995b2f93c5a51dc)