### PR TITLE
Fixes for reset and edit-shadow dialogs

### DIFF
--- a/src/preferences/widgets/edit_shadow_window.ts
+++ b/src/preferences/widgets/edit_shadow_window.ts
@@ -47,12 +47,12 @@ export const EditShadowWindow = GObject.registerClass(
         private declare _unfocus_toggle_button: Gtk.ToggleButton;
 
         // CssProvider to change style of preview widgets in edit window
-        private unfocus_provider!: Gtk.CssProvider;
-        private focus_provider!: Gtk.CssProvider;
+        private declare unfocus_provider: Gtk.CssProvider;
+        private declare focus_provider: Gtk.CssProvider;
 
         // Load box-shadow from settings
-        private focused_shadow!: BoxShadow;
-        private unfocused_shadow!: BoxShadow;
+        private declare focused_shadow: BoxShadow;
+        private declare unfocused_shadow: BoxShadow;
 
         _init() {
             super._init({

--- a/src/preferences/widgets/reset_dialog.ts
+++ b/src/preferences/widgets/reset_dialog.ts
@@ -18,15 +18,15 @@ export const ResetDialog = GObject.registerClass(
     {},
     class extends Gtk.Dialog {
         /** Keys to reset  */
-        private _reset_keys!: {
+        private declare _reset_keys: {
             [name in SchemasKeys]?: Cfg;
         };
         /** Global rounded corners settings to reset  */
-        private _reset_corners_cfg!: {
+        private declare _reset_corners_cfg: {
             [name in keyof RoundedCornersCfg]?: Cfg;
         };
         /** Used to select all CheckButtons  */
-        private _all_check_btns!: Gtk.CheckButton[];
+        private declare _all_check_btns: Gtk.CheckButton[];
 
         _init(): void {
             super._init({


### PR DESCRIPTION
Same as 6d0504de727bf590d202f1a99a648b9e89dd692d and f620bd238876037833195182c1d7a199fddc310f