### PR TITLE
Add "Sign into Github" step to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is the fork of the [original rounded-window-corners extension][14] by
 If you want to install the latest commit of the extension, you can get a
 pre-built archive from GitHub Actions.
 
-1. Sign into GitHub.
+1. Sign in to GitHub.
 2. Go to [the build action page](https://github.com/flexagoon/rounded-window-corners/actions/workflows/build.yml)
 3. Click on the latest workflow run
 4. Download the extension from the "artifacts" section at the bottom

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ This is the fork of the [original rounded-window-corners extension][14] by
 If you want to install the latest commit of the extension, you can get a
 pre-built archive from GitHub Actions.
 
-1. Go to [the build action page](https://github.com/flexagoon/rounded-window-corners/actions/workflows/build.yml)
-2. Click on the latest workflow run
-3. Download the extension from the "artifacts" section at the bottom
-4. Install it with the `gnome-extensions install` command
+1. Sign into GitHub.
+2. Go to [the build action page](https://github.com/flexagoon/rounded-window-corners/actions/workflows/build.yml)
+3. Click on the latest workflow run
+4. Download the extension from the "artifacts" section at the bottom
+5. Install it with the `gnome-extensions install` command
 
 ### From source code
 


### PR DESCRIPTION
The user needs to be signed in before downloading artifacts. For users who are not signed in, the artifact is a non-clickable `span`.

```html
<span class="text-bold color-fg-default" style="word-break: break-word;">rounded-window-corners@fxgn.shell-extension</span>
```