### PR TITLE
Gnome 45 compatibility

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -5,5 +5,5 @@
     "url": "https://github.com/flexagoon/rounded-window-corners",
     "gettext-domain": "rounded-window-corners@fxgn",
     "settings-schema": "org.gnome.shell.extensions.rounded-window-corners",
-    "shell-version": ["46"]
+    "shell-version": ["45", "46"]
 }


### PR DESCRIPTION
Some of us stay on the previous Fedora release and hold on to update for stability reasons. Fedora 39 uses Gnome 45 but the extension is set to work only on Gnome 46. The original extension never got officially released beyond Gnome 44. Can we add Gnome 45 compatibilty? From my testing it works well.