### PR TITLE
fix: modals in overview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import {WindowActorTracker} from './manager/effect_manager.js';
 import {connections} from './utils/connections.js';
 import {constants} from './utils/constants.js';
 import {_log, stackMsg} from './utils/log.js';
-import {init_settings, uninit_settings, settings} from './utils/settings.js';
+import {init_settings, settings, uninit_settings} from './utils/settings.js';
 import * as UI from './utils/ui.js';
 
 // types, which will be removed in output
@@ -117,7 +117,10 @@ export default class RoundedWindowCornersReborn extends Extension {
                 );
                 has_rounded_corners = UI.ShouldHasRoundedCorners(window, cfg);
             }
-            if (!(has_rounded_corners && shadow)) {
+            if (
+                !(has_rounded_corners && shadow) ||
+                window.has_attached_dialogs()
+            ) {
                 return;
             }
 


### PR DESCRIPTION
In the overview, each WindowPreview gets a copy of parent's effect to add additional shadow. But modal dialogs are placed within parent's WindowPreview, which in some cases would change the size of WindowPreview and lead to weird shadow. Since both main and modal windows already have rounded corners the only casualty of this patch is window shadow in the overview, which IMHO isn't really a big deal because it's already missing if window doesn't have rounded corners, for example maximized windows.

fixes #18