### PR TITLE
Added support for coloring unfocused windows different.

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 12\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-12-10 10:05+0000\n"
 "Last-Translator: Nadjib Chergui <chergui.cnadjib@outlook.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/rounded-window-"
@@ -84,67 +84,72 @@ msgstr "عرض الحدود"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "لون الحدود"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "لون الحدود"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "درجة تدوير زوايا الحدود"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "تمليس الزاوية"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "ظل النافذة"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "تخصيص نمط ظل النافذة ذات الزوايا المدورة"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "إبقاء الزوايا المدورة في وضع التكبير"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "إبقاء الزوايا المدورة في وضع ملء الشاشة"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "تعديلات"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 #, fuzzy
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "حاول إضافة الزوايا المدورة لطرفية كيتي (Kitty) في وايلاند (Wayland)"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "أضف بند الإعدادات في قائمة النقرة اليمنى للخلفية"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "تصحيح الأخطاء"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "تفعيل التسجيلات التقنية"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -152,7 +157,7 @@ msgstr ""
 "شغل <i>journalctl -o cat -f /usr/bin/gnome-shell</i> في الطرفية لتظهر "
 "التسجيلات"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "فتح نافذة إعادة الضبط"
@@ -307,11 +312,13 @@ msgid "Skip LibHandy Applications"
 msgstr "تجنب تطبيقات (LibHandy)"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "نمط ظل النافذة المختارة"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "نمط ظل النافذة الغير المختارة"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -320,28 +327,37 @@ msgid "Border Width"
 msgstr "عرض الحدود"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "لون الحدود"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "لون الحدود"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "درجة تدوير زوايا الحدود"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "تباعد"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "إبقاء الزوايا المدورة في وضع التكبير أو ملء الشاشة"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "تمليس الزاوية"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "إعدادات الزوايا المدورة..."
+
+#~ msgid "Border Color"
+#~ msgstr "لون الحدود"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "كبر الصف لاختيار نافذة."

--- a/po/cs.po
+++ b/po/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-04-25 17:52+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/rounded-window-"
@@ -87,66 +87,71 @@ msgstr "Šířka okraje"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Barva okraje"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Barva okraje"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Poloměr okraje"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Vyhlazování rohů"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Stín okna"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Přizpůsobení stínu zaobleného rohu okna"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Zachovat zaoblené rohy při maximalizaci"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Zachovat zaoblené rohy v režimu celé obrazovky"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Vylepšení"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Pokusit se přidat zaoblené rohy do aplikace Kitty Terminal ve Waylandu"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Upravit výplně klipů pro Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Přidat položku Nastavení do nabídky pravého tlačítka myši na pozadí"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Ladění"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Povolit protokol"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -154,7 +159,7 @@ msgstr ""
 "Pro zobrazení protokolu spusťte v terminálu příkaz <i>journalctl -o cat -f /"
 "usr/bin/gnome-shell</i>"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Otevřít dialogové okno Obnovit předvolby"
@@ -309,11 +314,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Přeskočit aplikace LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Styl stínu zaměřeného okna"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Styl stínu nezaměřeného okna"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -321,28 +328,37 @@ msgid "Border Width"
 msgstr "Šířka okraje"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Barva okraje"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Barva okraje"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Poloměr okraje"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Výplň"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Zachovat zaoblené rohy při maximalizaci nebo režimu na celou obrazovku"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Vyhlazování rohů"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Nastavení zaoblených rohů..."
+
+#~ msgid "Border Color"
+#~ msgstr "Barva okraje"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Rozbalte tento řádek a vyberte okno."

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-04-18 06:49+0000\n"
 "Last-Translator: Jörn Weigend <das.jott@gmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/rounded-window-"
@@ -88,67 +88,72 @@ msgstr "Rahmenbreite"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Rahmenfarbe"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Rahmenfarbe"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Rahmenradius"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Kantenglättung"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Fensterschatten"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Passe den Schatten von Fenstern mit abgerundeten Ecken an"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Zeige abgerundete Ecken bei Maximierung"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Zeige abgerundete Ecken im Vollbild"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Optimierungen"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 "Versuche abgerundete Ecken dem Kitty Terminal unter Wayland hinzuzufügen"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Optimiere die Innenabstände für Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Füge Einstellungseintrag zum Rechtsklickmenü des Hintergrunds hinzu"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Logging aktivieren"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -156,7 +161,7 @@ msgstr ""
 "Führe <i>journalctl -o cat -f /usr/bin/gnome-shell</i> im Terminal aus, um "
 "die Logs zu betrachten"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Zurücksetzungsoptionen anzeigen"
@@ -311,11 +316,13 @@ msgid "Skip LibHandy Applications"
 msgstr "LibHandy-Anwendungen auslassen"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Schattenstil für fokussierte Fenster"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Schattenstil für unfokussierte Fenster"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -323,28 +330,37 @@ msgid "Border Width"
 msgstr "Rahmenbreite"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Rahmenfarbe"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Rahmenfarbe"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Rahmenradius"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Innenabstand"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Zeige abgerundete Ecken im Vollbild oder bei Maximierung"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Kantenglättung"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Einstellungen für abgerundete Ecken..."
+
+#~ msgid "Border Color"
+#~ msgstr "Rahmenfarbe"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Eintrag aufklappen, um ein Fenster auszuwählen."

--- a/po/eo.po
+++ b/po/eo.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-01-04 20:51+0000\n"
 "Last-Translator: phlostically <phlostically@mailinator.com>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/rounded-window-"
@@ -73,67 +73,72 @@ msgstr "Randa larĝo"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Randa koloro"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Randa koloro"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Randa radiuso"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 msgid "Corner smoothing"
 msgstr ""
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 msgid "Windows shadow"
 msgstr ""
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 msgid "Keep rounded corners for maximized windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 msgid "Keep rounded corners for fullscreen windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 msgid "Open prefereces reset page"
 msgstr ""
 
@@ -277,40 +282,51 @@ msgid "Skip LibHandy Applications"
 msgstr "Preterpasi libhandy-programojn"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
-msgstr ""
+#, fuzzy
+msgid "Focused Window Shadow Style"
+msgstr "Enfokusa fenestro"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
-msgstr ""
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
+msgstr "Eksterfokusa fenestro"
 
 #: src/preferences/widgets/reset_page.ts:62
 msgid "Border Width"
 msgstr "Randa larĝo"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Randa koloro"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Randa koloro"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Randa radiuso"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr ""
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr ""
+
+#~ msgid "Border Color"
+#~ msgstr "Randa koloro"
 
 #~ msgid "Apply"
 #~ msgstr "Efektivigi"

--- a/po/es.po
+++ b/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-02 12:35+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,68 +86,73 @@ msgstr "Ancho de los bordes"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Color de los bordes"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Color de los bordes"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Radio de los bordes"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Suavizado de bordes"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Sombra de ventana"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalizar la sombra de la ventana redondeada"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Mantener bordes redondeados cuando se está maximizado"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Mantener bordes redondeados en pantalla completa"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Retoques"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Intentar añadir bordes redondeados a la terminal Kitty en Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Optimizar el relleno para Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Añadir entrada de configuración en el menú de click derecho del fondo de "
 "pantalla"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Depurar"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Habilitar registro"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -155,7 +160,7 @@ msgstr ""
 "Ejecute <i>journalctl -o cat -f /usr/bin/gnome-shell</i> en una terminal "
 "para ver el registro"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Abrir el diálogo de Restaurar preferencias"
@@ -313,11 +318,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Omitir aplicaciones LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Estilo de sombra de la ventana enfocada"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Estilo de sombra de ventana no enfocada"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -325,29 +332,38 @@ msgid "Border Width"
 msgstr "Ancho de los bordes"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Color de los bordes"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Color de los bordes"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Radio de los bordes"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Relleno"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 "Mantener bordes redondeados cuando se está maximizado o a pantalla completa"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Suavizado de bordes"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Configuración de Rounded Corners..."
+
+#~ msgid "Border Color"
+#~ msgstr "Color de los bordes"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Amplíe esta fila para elegir una ventana."

--- a/po/et.po
+++ b/po/et.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "Language: et\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -63,66 +63,70 @@ msgid "Border width"
 msgstr ""
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
-msgid "Border color"
+msgid "Focused border color"
 msgstr ""
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+msgid "Unfocused border color"
+msgstr ""
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 msgid "Corner radius"
 msgstr ""
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 msgid "Corner smoothing"
 msgstr ""
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 msgid "Windows shadow"
 msgstr ""
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 msgid "Keep rounded corners for maximized windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 msgid "Keep rounded corners for fullscreen windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 msgid "Open prefereces reset page"
 msgstr ""
 
@@ -260,11 +264,11 @@ msgid "Skip LibHandy Applications"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+msgid "Focused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+msgid "Unfocused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -272,22 +276,26 @@ msgid "Border Width"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+msgid "Focused Window Border Color"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:68
-msgid "Border Radius"
+#: src/preferences/widgets/reset_page.ts:64
+msgid "Unfocused Window Border Color"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:69
+msgid "Border Radius"
+msgstr ""
+
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2022-11-12 07:50+0000\n"
 "Last-Translator: Ilari Suhonen <ilari.suhonen@gmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,66 +86,71 @@ msgstr "Reunan leveys"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Reunan väri"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Reunan väri"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Reunan säde"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Kulman pehmitys"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Ikkunan varjo"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Mukauta pyöristetyn kulman varjoa"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Pidä pyöristetyt kulmat maksimoidussa tilassa"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Pidä pyöristetyt kulmat kokonäytön tilassa"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Hienosäädöt"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Koita pyöristää Kitty-pääteohjelman kulmat Waylandissa"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Muokkaa Kitty-pääteohjelman ylijäämäleikkausta"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Lisää asetukset-rivi taustan kontekstivalikkoon"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Vianetsintä"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Kirjoita lokiin"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -153,7 +158,7 @@ msgstr ""
 "Suorita <i>journalctl -o cat -f /usr/bin/gnome-shell</i> komentopäätteessä "
 "nähdäksesi lokin"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Avaa asetusten nollausvalikko"
@@ -308,11 +313,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Älä pyöristä LibHandy-ikkunoiden kulmia"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Keskitetyn ikkunan varjotyyli"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Keskittämättömän ikkunan varjo"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -320,28 +327,37 @@ msgid "Border Width"
 msgstr "Reunan leveys"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Reunan väri"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Reunan väri"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Reunan säde"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Ylijäämä"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Pidä pyöristetyt kulmat maksimoidussa ja kokonäytön tilassa"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Kulman pehmitys"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Kulmienpyöristyksen asetukset..."
+
+#~ msgid "Border Color"
+#~ msgstr "Reunan väri"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Laajenna rivi valitaksesi ikkunan."

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-10-11 16:02+0000\n"
 "Last-Translator: luxluth <delphin.blehoussi93@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,67 +86,72 @@ msgstr "Largeur de la bordure"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Couleur de la bordure"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Couleur de la bordure"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Rayon du coin"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Lissage du coin"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Ombre de la fenêtre"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Customiser l'ombre de la bordure de la fenêtre"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Garder les coins arrondis quand maximisé"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Garder les coins arrondis en plein écran"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Customisations"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Essayer d'ajouter des coins arrondis à la console Kitty sous Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Customiser les marges de la console Kitty"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Ajoute un accès aux paramètres dans le menu clique-droit de l'arrière plan"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Débogage"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Activer les journaux"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -154,7 +159,7 @@ msgstr ""
 "Exécutez la command <i>journalctl -o cat -f /usr/bin/gnome-shell</i> dans un "
 "terminal pour voir les journaux"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Ouvrir le dialogue de réinitialisation des paramètres"
@@ -312,11 +317,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Ne pas modifier les applications utilisant LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Style de l'ombre de la fenêtre sélectionnée"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Style de l'ombre de la fenêtre non active"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -324,28 +331,37 @@ msgid "Border Width"
 msgstr "Largeur de la bordure"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Couleur de la bordure"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Couleur de la bordure"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Rayon du coin"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Bordure"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Garder les coins arrondis quand maximisé ou en plein écran"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Lissage du coin"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Paramètres de coins arrondis..."
+
+#~ msgid "Border Color"
+#~ msgstr "Couleur de la bordure"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Développer la ligne pour choisir une fenêtre."

--- a/po/hu.po
+++ b/po/hu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-10-01 14:00+0000\n"
 "Last-Translator: olevo <imagyarcsik@gmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/rounded-window-"
@@ -73,68 +73,73 @@ msgstr "A border szélessége"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "A border széle"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "A border széle"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "A border radius vastagsága"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "A sarkok simítása/simasága"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 msgid "Windows shadow"
 msgstr ""
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 msgid "Keep rounded corners for maximized windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 msgid "Keep rounded corners for fullscreen windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Napló bekapcsolása"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 msgid "Open prefereces reset page"
 msgstr ""
 
@@ -277,12 +282,14 @@ msgid "Skip LibHandy Applications"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
-msgstr ""
+#, fuzzy
+msgid "Focused Window Shadow Style"
+msgstr "Ablak előtérbe helyezése"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
-msgstr ""
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
+msgstr "Ablak előtérbe helyezése"
 
 #: src/preferences/widgets/reset_page.ts:62
 msgid "Border Width"
@@ -290,28 +297,37 @@ msgstr "A border szélessége"
 
 #: src/preferences/widgets/reset_page.ts:63
 #, fuzzy
-msgid "Border Color"
+msgid "Focused Window Border Color"
 msgstr "A border széle"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "A border széle"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "A border radius vastagsága"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "A sarkok simítása/simasága"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Border Color"
+#~ msgstr "A border széle"
 
 #~ msgid "Can't add to list, because it has exists"
 #~ msgstr "Sikertelen hozzáadás, ez már létezik"

--- a/po/id.po
+++ b/po/id.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-05-24 00:51+0000\n"
 "Last-Translator: Reza Almanda <rezaalmanda27@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/rounded-"
@@ -86,66 +86,71 @@ msgstr "Lebar Border"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Warna Border"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Warna Border"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Radius Border"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Penghalusan Sudut"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Bayangan Jendela"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Sesuaikan bayangan jendela sudut membulat"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Pertahankan Sudut Bulat saat Dimaksimalkan"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Pertahankan Sudut Bulat saat Layar Penuh"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Oprekan"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Coba tambahkan sudut membulat ke Terminal Kitty di Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Tweak lapisan klip untuk Terminal Kitty"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Tambahkan Entri Pengaturan di menu klik kanan Latar Belakang"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Aktifkan Log"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -153,7 +158,7 @@ msgstr ""
 "Jalankan <i>journalctl -o cat -f /usr/bin/gnome-shell</i> di terminal untuk "
 "melihat log"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Buka Dialog Atur Ulang Preferensi"
@@ -310,11 +315,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Lewati Aplikasi LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Gaya Bayangan Jendela Fokus"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Gaya Bayangan Jendela Tidak Fokus"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -322,28 +329,37 @@ msgid "Border Width"
 msgstr "Lebar Border"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Warna Border"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Warna Border"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Radius Border"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Lapisan"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Pertahankan Sudut Bulat saat Dimaksimalkan atau Layar Penuh"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Penghalusan Sudut"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Pengaturan Sudut Bulat..."
+
+#~ msgid "Border Color"
+#~ msgstr "Warna Border"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Luaskan baris ini untuk memilih jendela."

--- a/po/it.po
+++ b/po/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2024-02-25 14:01+0000\n"
 "Last-Translator: repex97 <repetto.andrea025@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/rounded-window-"
@@ -87,68 +87,73 @@ msgstr "Larghezza del bordo"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Colore del bordo"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Colore del bordo"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Raggio del bordo"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Smussamento del bordo"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Ombra della Finestra"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalizza l'ombra del bordo arrotondato"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Mantieni I Bordi Arrotondati quando Massimizzato"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Mantieni I Bordi Arrotondati In Schermo Intero"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Modifiche"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Prova ad arrotondare i bordi al terminale Kitty su Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Personalizza i margini per Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Aggiungi tra le impostazioni del menu del tasto destro del mouse sul "
 "Background"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Abilita i Log"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -156,7 +161,7 @@ msgstr ""
 "Esegui <i>journalctl -o cat -f /usr/bin/gnome-shell</i> nel terminale per "
 "vedere i log"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Apri il Dialogo Per Resettare le Preferenze"
@@ -311,11 +316,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignora Applicazioni LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Stile dell'ombra della finestra attiva"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Stile ombreggiatura finestra in secondo piano"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -323,28 +330,37 @@ msgid "Border Width"
 msgstr "Larghezza del bordo"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Colore del bordo"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Colore del bordo"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Raggio del bordo"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Padding"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Mantieni I Bordi Arrotondati Quando Massimizzato o a Schermo Intero"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Smussamento del bordo"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Impostazioni per i Bordi Arrotondati..."
+
+#~ msgid "Border Color"
+#~ msgstr "Colore del bordo"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Espandi questa riga per selezionare una finestra."

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-21 15:37+0000\n"
 "Last-Translator: maboroshin <maboroshin@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,66 +86,71 @@ msgstr "境界線の幅"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "境界線の色"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "境界線の色"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "境界線の角丸サイズ"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "角を滑らかに"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "ウィンドウの影"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "角丸ウィンドウの影を指定"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "最大化時に角丸を維持"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "全画面時に角丸を維持"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "背景の右クリックメニューに設定項目を追加"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "デバッグ"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "ログを有効化"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -153,7 +158,7 @@ msgstr ""
 "ログ閲覧にはターミナルで <i>journalctl -o cat -f /usr/bin/gnome-shell</i> を"
 "実行"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "設定初期化のダイアログを開く"
@@ -306,11 +311,11 @@ msgid "Skip LibHandy Applications"
 msgstr "LibHandy のアプリは無視"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+msgid "Focused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+msgid "Unfocused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -318,28 +323,37 @@ msgid "Border Width"
 msgstr "境界線の幅"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "境界線の色"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "境界線の色"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "境界線の角丸サイズ"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "最大化や全画面時に角丸を維持"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "角を滑らかに"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "角丸の設定..."
+
+#~ msgid "Border Color"
+#~ msgstr "境界線の色"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "この行を展開しウィンドウを選択。"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2022-09-15 06:16+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/rounded-"
@@ -71,68 +71,72 @@ msgid "Border width"
 msgstr ""
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
-msgid "Border color"
+msgid "Focused border color"
 msgstr ""
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+msgid "Unfocused border color"
+msgstr ""
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 msgid "Corner radius"
 msgstr ""
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 msgid "Corner smoothing"
 msgstr ""
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 msgid "Windows shadow"
 msgstr ""
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Behold avrundede hjørner når vinduet er maksimert eller flislagt."
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Behold avrundede vinduer når vindu er i fullskjermsvisning."
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Legg til innstillingsoppføring i høyreklikksmenyen for bakgrunn"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 msgid "Open prefereces reset page"
 msgstr ""
 
@@ -274,11 +278,11 @@ msgid "Skip LibHandy Applications"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+msgid "Focused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+msgid "Unfocused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -286,22 +290,26 @@ msgid "Border Width"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+msgid "Focused Window Border Color"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:68
-msgid "Border Radius"
+#: src/preferences/widgets/reset_page.ts:64
+msgid "Unfocused Window Border Color"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:69
+msgid "Border Radius"
+msgstr ""
+
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-02 12:35+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,66 +86,71 @@ msgstr "Randbreedte"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Randkleur"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Randkleur"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Randstraal"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Hoeken gladstrijken"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Vensterschaduw"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Pas de schaduw van afgeronde vensters aan"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Afgeronde hoeken van gemaximaliseerde vensters behouden"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Afgeronde hoeken van schermvullende vensters behouden"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Trucs"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Kitty Terminal voorzien van afgeronde hoeken op Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Opvullingen van Kitty Terminal verbeteren"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Voorkeurenitem tonen in rechtermuisknopmenu van achtergrond"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Foutopsporing"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Logboek bijhouden"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -153,7 +158,7 @@ msgstr ""
 "Voer <i>journalctl -o cat -f /usr/bin/gnome-shell</i> uit in een "
 "terminalvenster om het logboek te bekijken"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Open het voorkeurenherstelvenster"
@@ -310,11 +315,13 @@ msgid "Skip LibHandy Applications"
 msgstr "LibHandy-apps negeren"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Schaduw van vensterfocus"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Schaduw stijl van ongefocust venster"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -322,29 +329,38 @@ msgid "Border Width"
 msgstr "Randbreedte"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Randkleur"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Randkleur"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Randstraal"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Opvulling"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 "Afgeronde hoeken van gemaximaliseerde en schermvullende vensters behouden"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Hoeken gladstrijken"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Afgeronde hoeken-voorkeuren…"
+
+#~ msgid "Border Color"
+#~ msgstr "Randkleur"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Klap deze rij uit om een venster te kiezen."

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-10-29 05:13+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/rounded-window-"
@@ -86,68 +86,73 @@ msgstr "Grubość obramowania"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Kolor obramowania"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Kolor obramowania"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Zaokrąglenie krawędzi"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "wygładzanie krawędzi"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Styl cienia wybranego okna"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Dostosuj cień okien z zaokrąglonymi krawędziami"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Zaokrąglaj okna kiedy zmaksymalizowane"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Zaokrąglaj okna w pełnym ekranie"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Ulepszenia"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Dodaj opcję do menu pojawiającego się po kliknięciu prawym przyciskiem myszy "
 "na pulpicie"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debuguj"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Włącz logi"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -155,7 +160,7 @@ msgstr ""
 "Aby zobaczyć log, uruchom w terminalu polecenie <i>journalctl -o cat -f /usr/"
 "bin/gnome-shell</i>"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Otwórz okno resetowania ustawień"
@@ -309,11 +314,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Pomiń aplikacje wykorzytujące LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Styl cienia wybranego okna"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Styl cienia nieaktywnego okna"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -321,28 +328,37 @@ msgid "Border Width"
 msgstr "Grubość obramowania"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Kolor obramowania"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Kolor obramowania"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Zaokrąglenie krawędzi"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Margines wewnętrzny"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Zaokrąglaj okna kiedy zmaksymalizowane lub w trybie pełnego ekranu"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "wygładzanie krawędzi"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Ustawienia zaokrąglonych narożników..."
+
+#~ msgid "Border Color"
+#~ msgstr "Kolor obramowania"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Zwiększ ten rząd aby wybrać okno"

--- a/po/pt.po
+++ b/po/pt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 12\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-12-21 14:06+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/rounded-"
@@ -87,67 +87,72 @@ msgstr "Largura da Borda"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Cor da Borda"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Cor da Borda"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Raio da Borda"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Suavização dos Cantos"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Sombra da janela"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalize a sombra dos cantos da janela"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Manter Cantos Arredondados ao Maximizar"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Manter Cantos Arredondados em Ecrã Inteiro"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Ajustes"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Tente adicionar cantos arredondados ao Terminal Kitty em Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Ajustar preenchimento de clipe para o Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 "Adicionar entrada de configurações no menu de fundo do botão direito do rato"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Ativar Log"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -155,7 +160,7 @@ msgstr ""
 "Execute <i>journalctl -o cat -f /usr/bin/gnome-shell</i> no terminal para "
 "ver o log"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Abrir caixa de diálogo de Redefinição de Configurações"
@@ -314,11 +319,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignorar Aplicações Usando LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Focada"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Desfocada"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -326,28 +333,37 @@ msgid "Border Width"
 msgstr "Largura da Borda"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Cor da Borda"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Cor da Borda"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Raio da Borda"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Margem"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Manter Cantos Arredondados ao Maximizar ou em Ecrã Inteiro"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Suavização dos Cantos"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Configurações de Cantos Arredondados..."
+
+#~ msgid "Border Color"
+#~ msgstr "Cor da Borda"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Expanda esta linha para escolher uma janela."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-11-12 08:23+0000\n"
 "Last-Translator: Matheus <cybercountry@proton.me>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -87,66 +87,71 @@ msgstr "Largura da Borda"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Cor da Borda"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Cor da Borda"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Raio da Borda"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Suavização dos Cantos"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Sombra da janela"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Personalize a sombra dos cantos da janela"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Manter Cantos Arredondados ao Maximizar"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Manter Cantos Arredondados em Tela Cheia"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Ajustes"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Debug"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Habilitar Log"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -154,7 +159,7 @@ msgstr ""
 "Execute <i>journalctl -o cat -f /usr/bin/gnome-shell</i> no terminal para "
 "ver o log"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Abrir caixa de diálogo de Redefinição de Configurações"
@@ -312,11 +317,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Ignorar Aplicativos Usando LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Focada"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Estilo de Sombra da Janela Desfocada"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -324,28 +331,37 @@ msgid "Border Width"
 msgstr "Largura da Borda"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Cor da Borda"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Cor da Borda"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Raio da Borda"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Margem"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Manter Cantos Arredondados ao Maximizar ou em Tela Cheia"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Suavização dos Cantos"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Configurações de Cantos Arredondados..."
+
+#~ msgid "Border Color"
+#~ msgstr "Cor da Borda"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Expanda esta linha para escolher uma janela."

--- a/po/rounded-window-corners@fxgn.pot
+++ b/po/rounded-window-corners@fxgn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:58-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,66 +74,70 @@ msgid "Border width"
 msgstr ""
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
-msgid "Border color"
+msgid "Focused border color"
 msgstr ""
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+msgid "Unfocused border color"
+msgstr ""
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 msgid "Corner radius"
 msgstr ""
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 msgid "Corner smoothing"
 msgstr ""
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 msgid "Windows shadow"
 msgstr ""
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr ""
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 msgid "Keep rounded corners for maximized windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 msgid "Keep rounded corners for fullscreen windows"
 msgstr ""
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr ""
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr ""
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr ""
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr ""
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr ""
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 msgid "Open prefereces reset page"
 msgstr ""
 
@@ -271,11 +275,11 @@ msgid "Skip LibHandy Applications"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+msgid "Focused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+msgid "Unfocused Window Shadow Style"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -283,22 +287,26 @@ msgid "Border Width"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+msgid "Focused Window Border Color"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:68
-msgid "Border Radius"
+#: src/preferences/widgets/reset_page.ts:64
+msgid "Unfocused Window Border Color"
 msgstr ""
 
 #: src/preferences/widgets/reset_page.ts:69
+msgid "Border Radius"
+msgstr ""
+
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr ""
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-09 15:37+0000\n"
 "Last-Translator: Evgeniy Khramov <thejenjagamertjg@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/rounded-window-"
@@ -88,66 +88,71 @@ msgstr "Ширина границы"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Цвет границы"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Цвет границы"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Радиус границы"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Сглаживание углов"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Тень окна"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Настроить тень окна с закругленными углами"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Сохранить закругленные углы, когда они развернуты"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Сохранить закругленные углы при полноэкранном режиме"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Твики"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Попробовать добавить закругленные углы в Kitty Terminal в Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Настроить отступы зажимов для терминала Kitty Terminal"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Добавить запись настроек в меню правой кнопки мыши фона"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Отладка"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Включить журнал"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -155,7 +160,7 @@ msgstr ""
 "Запустите <i>journalctl -o cat -f /usr/bin/gnome-shell</i> в терминале, "
 "чтобы посмотреть журнал"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Открыть диалог сброса настроек"
@@ -311,11 +316,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Пропустить приложения LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Стиль тени активного окна"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Стиль тени неактивного окна"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -323,28 +330,37 @@ msgid "Border Width"
 msgstr "Ширина границы"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Цвет границы"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Цвет границы"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Радиус границы"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Отсуп"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Сохранить закругленные углы при максимальном или полном экране"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Сглаживание углов"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Настройки закругленных углов..."
+
+#~ msgid "Border Color"
+#~ msgstr "Цвет границы"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Разверните этот ряд, чтобы выбрать окно."

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-05-14 22:51+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/rounded-window-"
@@ -87,66 +87,71 @@ msgstr "Kenarlık Genişliği"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Kenarlık Rengi"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Kenarlık Rengi"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Kenarlık Yarıçapı"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Köşe Düzleştirme"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Pencere Gölgesi"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Yuvarlak köşeli pencerenin gölgesini özelleştir"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Ekranı Kapladığında Yuvarlatılmış Köşeleri Koru"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Tam Ekran Olduğunda Yuvarlatılmış Köşeleri Koru"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "İnce Ayarlar"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Wayland'da Kitty Terminal'e yuvarlatılmış köşeler eklemeye çalış"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Kitty Terminal için kırpma dolgularını ayarla"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Arka Plan'ın sağ tıklama menüsüne Ayarlar Girdisi Ekle"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Hata Ayıkla"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Günlüğü Etkinleştir"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -154,7 +159,7 @@ msgstr ""
 "Günlüğü görmek için uçbirimde <i>journalctl -o cat -f /usr/bin/gnome-shell</"
 "i> komutunu çalıştırın"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Tercihleri Sıfırla İletişim Kutusunu Aç"
@@ -311,11 +316,13 @@ msgid "Skip LibHandy Applications"
 msgstr "LibHandy Uygulamalarını Atla"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Odaklı Pencere Gölge Biçemi"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Odaklanmamış Pencere Gölge Biçemi"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -323,28 +330,37 @@ msgid "Border Width"
 msgstr "Kenarlık Genişliği"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Kenarlık Rengi"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Kenarlık Rengi"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Kenarlık Yarıçapı"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Dolgu"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Ekranı Kapladığında veya Tam Ekranda Yuvarlatılmış Köşeleri Koru"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Köşe Düzleştirme"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Yuvarlatılmış Köşe Ayarları..."
+
+#~ msgid "Border Color"
+#~ msgstr "Kenarlık Rengi"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Bir pencere seçmek için bu sırayı genişlet."

--- a/po/uk.po
+++ b/po/uk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-27 22:37+0000\n"
 "Last-Translator: Dan <denqwerta@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/rounded-window-"
@@ -89,66 +89,71 @@ msgstr "Ширина рамки"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "Колір рамки"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "Колір рамки"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "Радіус рамки"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "Згладжування кутів"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "Тінь вікна"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "Налаштувати тінь заокругленого кутового вікна"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "Зберігати заокруглені кути при збільшенні"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "Зберігати заокруглені кути в повноекранному режимі"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "Твіки"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "Спробувати додати заокруглені кути до терміналу Kitty у Wayland"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "Налаштувати внутрішній відступ для терміналу Kitty"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "Додати запис налаштувань у меню фону правою кнопкою миші"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "Налагодження"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "Увімкнути журнал"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
@@ -156,7 +161,7 @@ msgstr ""
 "Запустіть <i>journalctl -o cat -f /usr/bin/gnome-shell</i> у терміналі, щоб "
 "переглянути журнал"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "Відкрити діалогове вікно скидання налаштувань"
@@ -314,11 +319,13 @@ msgid "Skip LibHandy Applications"
 msgstr "Пропустити застосунки LibHandy"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "Стиль тіні вибраного вікна"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "Стиль тіні розфокусованого вікна"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -326,28 +333,37 @@ msgid "Border Width"
 msgstr "Ширина рамки"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "Колір рамки"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "Колір рамки"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "Радіус рамки"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "Відступ"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "Зберігати заокруглені кути при збільшенні та в повноекранному режимі"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "Згладжування кутів"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "Налаштування заокруглених кутів..."
+
+#~ msgid "Border Color"
+#~ msgstr "Колір рамки"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "Розгорніть цей рядок, щоб вибрати вікно."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-14 21:07+0300\n"
+"POT-Creation-Date: 2024-11-03 10:45-0800\n"
 "PO-Revision-Date: 2023-03-02 12:35+0000\n"
 "Last-Translator: Yi <yilozt@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -85,73 +85,78 @@ msgstr "边框大小"
 
 #: src/preferences/pages/general.ui:57 src/preferences/pages/general.ui:65
 #, fuzzy
-msgid "Border color"
+msgid "Focused border color"
 msgstr "边框颜色"
 
-#: src/preferences/pages/general.ui:74
+#: src/preferences/pages/general.ui:74 src/preferences/pages/general.ui:82
+#, fuzzy
+msgid "Unfocused border color"
+msgstr "边框颜色"
+
+#: src/preferences/pages/general.ui:91
 #: src/preferences/widgets/customeffect_row.ts:16
 #, fuzzy
 msgid "Corner radius"
 msgstr "圆角半径"
 
-#: src/preferences/pages/general.ui:101
+#: src/preferences/pages/general.ui:118
 #: src/preferences/widgets/customeffect_row.ts:25
 #, fuzzy
 msgid "Corner smoothing"
 msgstr "圆角平滑程度"
 
-#: src/preferences/pages/general.ui:127
+#: src/preferences/pages/general.ui:144
 #, fuzzy
 msgid "Windows shadow"
 msgstr "窗口阴影"
 
-#: src/preferences/pages/general.ui:128
+#: src/preferences/pages/general.ui:145
 msgid "Customize the shadow of the rounded corner window"
 msgstr "设置圆角窗口的阴影"
 
-#: src/preferences/pages/general.ui:140
+#: src/preferences/pages/general.ui:157
 #, fuzzy
 msgid "Keep rounded corners for maximized windows"
 msgstr "最大化时保留圆角"
 
-#: src/preferences/pages/general.ui:145
+#: src/preferences/pages/general.ui:162
 #, fuzzy
 msgid "Keep rounded corners for fullscreen windows"
 msgstr "窗口全屏时保留圆角"
 
-#: src/preferences/pages/general.ui:155
+#: src/preferences/pages/general.ui:172
 msgid "Tweaks"
 msgstr "调整"
 
-#: src/preferences/pages/general.ui:158
+#: src/preferences/pages/general.ui:175
 msgid "Try to add rounded corners to Kitty Terminal in Wayland"
 msgstr "在 Wayland 下为 Kitty 终端添加圆角效果"
 
-#: src/preferences/pages/general.ui:159
+#: src/preferences/pages/general.ui:176
 msgid "Tweak clip paddings for Kitty Terminal"
 msgstr "调整 Kitty 终端的剪裁半径"
 
-#: src/preferences/pages/general.ui:164
+#: src/preferences/pages/general.ui:181
 msgid "Add Settings Entry in right-click menu of Background"
 msgstr "将首选项入口添加到桌面背景的右键菜单"
 
-#: src/preferences/pages/general.ui:171
+#: src/preferences/pages/general.ui:188
 msgid "Debug"
 msgstr "调试"
 
-#: src/preferences/pages/general.ui:174
-#: src/preferences/widgets/reset_page.ts:64
+#: src/preferences/pages/general.ui:191
+#: src/preferences/widgets/reset_page.ts:65
 msgid "Enable Log"
 msgstr "启用日志"
 
-#: src/preferences/pages/general.ui:175
+#: src/preferences/pages/general.ui:192
 #, fuzzy
 msgid ""
 "Run journalctl -o cat -f /usr/bin/gnome-shell in terminal to see the log"
 msgstr ""
 "可以在终端里运行 <i>journalctl -o cat -f /usr/bin/gnome-shell</i> 来查看日志"
 
-#: src/preferences/pages/general.ui:184
+#: src/preferences/pages/general.ui:201
 #, fuzzy
 msgid "Open prefereces reset page"
 msgstr "打开重置对话框"
@@ -306,11 +311,13 @@ msgid "Skip LibHandy Applications"
 msgstr "跳过 LibHandy 应用"
 
 #: src/preferences/widgets/reset_page.ts:60
-msgid "Focus Window Shadow Style"
+#, fuzzy
+msgid "Focused Window Shadow Style"
 msgstr "已获取焦点窗口阴影"
 
 #: src/preferences/widgets/reset_page.ts:61
-msgid "Unfocus Window Shadow Style"
+#, fuzzy
+msgid "Unfocused Window Shadow Style"
 msgstr "未获取焦点窗口阴影"
 
 #: src/preferences/widgets/reset_page.ts:62
@@ -318,28 +325,37 @@ msgid "Border Width"
 msgstr "边框大小"
 
 #: src/preferences/widgets/reset_page.ts:63
-msgid "Border Color"
+#, fuzzy
+msgid "Focused Window Border Color"
 msgstr "边框颜色"
 
-#: src/preferences/widgets/reset_page.ts:68
+#: src/preferences/widgets/reset_page.ts:64
+#, fuzzy
+msgid "Unfocused Window Border Color"
+msgstr "边框颜色"
+
+#: src/preferences/widgets/reset_page.ts:69
 msgid "Border Radius"
 msgstr "圆角半径"
 
-#: src/preferences/widgets/reset_page.ts:69
+#: src/preferences/widgets/reset_page.ts:70
 msgid "Padding"
 msgstr "剪裁边距"
 
-#: src/preferences/widgets/reset_page.ts:71
+#: src/preferences/widgets/reset_page.ts:72
 msgid "Keep Rounded Corners when Maximized or Fullscreen"
 msgstr "在窗口最大化或全屏时保留圆角"
 
-#: src/preferences/widgets/reset_page.ts:73
+#: src/preferences/widgets/reset_page.ts:74
 msgid "Corner Smoothing"
 msgstr "圆角平滑程度"
 
 #: src/utils/background_menu.ts:60 src/utils/background_menu.ts:82
 msgid "Rounded Corners Settings..."
 msgstr "圆角设置…"
+
+#~ msgid "Border Color"
+#~ msgstr "边框颜色"
 
 #~ msgid "Expand this row to pick a window."
 #~ msgstr "展开此控件以选取窗口。"

--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners-reborn.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners-reborn.gschema.xml
@@ -35,8 +35,13 @@
       <default>0</default>
     </key>
 
-    <key name="border-color" type="(dddd)">
-      <summary>Border color for rounded corners window</summary>
+    <key name="focused-border-color" type="(dddd)">
+      <summary>Border color for focused rounded corners window</summary>
+      <default>(0.5, 0.5, 0.5, 1.0)</default>
+    </key>
+
+    <key name="unfocused-border-color" type="(dddd)">
+      <summary>Border color for unfocused rounded corners window</summary>
       <default>(0.5, 0.5, 0.5, 1.0)</default>
     </key>
     

--- a/src/effect/rounded_corners_effect.ts
+++ b/src/effect/rounded_corners_effect.ts
@@ -62,12 +62,19 @@ export const RoundedCornersEffect = GObject.registerClass(
          * @param windowBounds - Bounds of the window without padding
          */
         updateUniforms(
+            focused: boolean,
             scaleFactor: number,
             config: RoundedCornerSettings,
             windowBounds: Bounds,
         ) {
             const borderWidth = getPref('border-width') * scaleFactor;
-            const borderColor = getPref('border-color');
+            const focusedBorderColor = getPref('focused-border-color');
+            const unfocusedBorderColor = getPref('unfocused-border-color');
+
+            var borderColor = focusedBorderColor;
+            if (!focused) {
+                borderColor = unfocusedBorderColor;
+            }
 
             const outerRadius = config.borderRadius * scaleFactor;
             const {padding, smoothing} = config;

--- a/src/manager/event_handlers.ts
+++ b/src/manager/event_handlers.ts
@@ -148,7 +148,10 @@ export function onRestacked(): void {
 
 export const onSizeChanged = refreshRoundedCorners;
 
-export const onFocusChanged = refreshShadow;
+export function onFocusChanged(actor: RoundedWindowActor): void {
+    refreshShadow(actor);
+    refreshRoundedCorners(actor);
+}
 
 export function onSettingsChanged(key: SchemaKey): void {
     switch (key) {
@@ -163,7 +166,8 @@ export function onSettingsChanged(key: SchemaKey): void {
             break;
         case 'global-rounded-corner-settings':
         case 'custom-rounded-corner-settings':
-        case 'border-color':
+        case 'focused-border-color':
+        case 'unfocused-border-color':
         case 'border-width':
         case 'tweak-kitty-terminal':
             refreshAllRoundedCorners();
@@ -284,6 +288,7 @@ function refreshRoundedCorners(actor: RoundedWindowActor): void {
 
     // When window size is changed, update uniforms for corner rounding shader.
     effect.updateUniforms(
+        win.appears_focused,
         windowScaleFactor(win),
         cfg,
         computeBounds(actor, windowContentOffset),

--- a/src/preferences/pages/general.ts
+++ b/src/preferences/pages/general.ts
@@ -25,7 +25,8 @@ export const General = GObject.registerClass(
             'skip_libadwaita',
             'skip_libhandy',
             'border_width',
-            'border_color',
+            'focused_border_color',
+            'unfocused_border_color',
             'corner_radius',
             'corner_smoothing',
             'keep_for_maximized',
@@ -40,7 +41,8 @@ export const General = GObject.registerClass(
         private declare _skip_libadwaita: Adw.SwitchRow;
         private declare _skip_libhandy: Adw.SwitchRow;
         private declare _border_width: Gtk.Adjustment;
-        private declare _border_color: Gtk.ColorDialogButton;
+        private declare _focused_border_color: Gtk.ColorDialogButton;
+        private declare _unfocused_border_color: Gtk.ColorDialogButton;
         private declare _corner_radius: Gtk.Adjustment;
         private declare _corner_smoothing: Gtk.Adjustment;
         private declare _keep_for_maximized: Adw.SwitchRow;
@@ -77,15 +79,32 @@ export const General = GObject.registerClass(
                 Gio.SettingsBindFlags.DEFAULT,
             );
 
-            const color = new Gdk.RGBA();
-            [color.red, color.green, color.blue, color.alpha] =
-                getPref('border-color');
-            this._border_color.set_rgba(color);
-            this._border_color.connect(
+            const focused_color = new Gdk.RGBA();
+            [focused_color.red, focused_color.green, focused_color.blue, focused_color.alpha] =
+                getPref('focused-border-color');
+            this._focused_border_color.set_rgba(focused_color);
+            this._focused_border_color.connect(
                 'notify::rgba',
                 (btn: Gtk.ColorDialogButton) => {
                     const color = btn.get_rgba();
-                    setPref('border-color', [
+                    setPref('focused-border-color', [
+                        color.red,
+                        color.green,
+                        color.blue,
+                        color.alpha,
+                    ]);
+                },
+            );
+
+            const unfocused_color = new Gdk.RGBA();
+            [unfocused_color.red, unfocused_color.green, unfocused_color.blue, unfocused_color.alpha] =
+                getPref('unfocused-border-color');
+            this._unfocused_border_color.set_rgba(unfocused_color);
+            this._unfocused_border_color.connect(
+                'notify::rgba',
+                (btn: Gtk.ColorDialogButton) => {
+                    const color = btn.get_rgba();
+                    setPref('unfocused-border-color', [
                         color.red,
                         color.green,
                         color.blue,

--- a/src/preferences/pages/general.ui
+++ b/src/preferences/pages/general.ui
@@ -24,7 +24,7 @@
     <child>
       <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Global settings</property>
-        <property name="description" translatable="yes">These settings will have effect on all windows</property>
+        <property name="description" translatable="yes">These settings will have an effect on all windows</property>
         <child>
           <object class="AdwActionRow">
             <property name="title" translatable="yes">Border width</property>
@@ -54,15 +54,32 @@
         </child>
         <child>
           <object class="AdwActionRow">
-            <property name="title" translatable="yes">Border color</property>
+            <property name="title" translatable="yes">Focused border color</property>
             <property name="activatable">true</property>
-            <property name="activatable-widget">border_color</property>
+            <property name="activatable-widget">focused_border_color</property>
             <child>
-              <object class="GtkColorDialogButton" id="border_color">
+              <object class="GtkColorDialogButton" id="focused_border_color">
                 <property name="valign">center</property>
                 <property name="dialog">
                   <object class="GtkColorDialog">
-                    <property name="title" translatable="yes">Border color</property>
+                    <property name="title" translatable="yes">Focused border color</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Unfocused border color</property>
+            <property name="activatable">true</property>
+            <property name="activatable-widget">unfocused_border_color</property>
+            <child>
+              <object class="GtkColorDialogButton" id="unfocused_border_color">
+                <property name="valign">center</property>
+                <property name="dialog">
+                  <object class="GtkColorDialog">
+                    <property name="title" translatable="yes">Unfocused border color</property>
                   </object>
                 </property>
               </object>

--- a/src/preferences/widgets/reset_page.ts
+++ b/src/preferences/widgets/reset_page.ts
@@ -57,10 +57,11 @@ export const ResetPage = GObject.registerClass(
                     _('Skip LibAdwaita Applications'),
                 ),
                 'skip-libhandy-app': new Cfg(_('Skip LibHandy Applications')),
-                'focused-shadow': new Cfg(_('Focus Window Shadow Style')),
-                'unfocused-shadow': new Cfg(_('Unfocus Window Shadow Style')),
+                'focused-shadow': new Cfg(_('Focused Window Shadow Style')),
+                'unfocused-shadow': new Cfg(_('Unfocused Window Shadow Style')),
                 'border-width': new Cfg(_('Border Width')),
-                'border-color': new Cfg(_('Border Color')),
+                'focused-border-color': new Cfg(_('Focused Window Border Color')),
+                'unfocused-border-color': new Cfg(_('Unfocused Window Border Color')),
                 'debug-mode': new Cfg(_('Enable Log')),
             };
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -23,7 +23,8 @@ type Schema = {
     'skip-libadwaita-app': boolean;
     'skip-libhandy-app': boolean;
     'border-width': number;
-    'border-color': [number, number, number, number];
+    'focused-border-color': [number, number, number, number];
+    'unfocused-border-color': [number, number, number, number];
     'global-rounded-corner-settings': RoundedCornerSettings;
     'custom-rounded-corner-settings': CustomRoundedCornerSettings;
     'focused-shadow': BoxShadow;
@@ -43,7 +44,8 @@ const Schema = {
     'skip-libadwaita-app': 'b',
     'skip-libhandy-app': 'b',
     'border-width': 'i',
-    'border-color': '(dddd)',
+    'focused-border-color': '(dddd)',
+    'unfocused-border-color': '(dddd)',
     'global-rounded-corner-settings': 'a{sv}',
     'custom-rounded-corner-settings': 'a{sv}',
     'focused-shadow': 'a{si}',


### PR DESCRIPTION
- Added additional value for unfocused_border_color.
- Added color selection to preferences for unfocused_border_color.
- Applies the appropriate border color on redraw.
- Applies the appropriate border color on focus change.

![image](https://github.com/user-attachments/assets/adade922-4c2c-422a-9314-15d8915521c9)

Closes #41 