### PR TITLE
Improve Blur-My-Shell compatibility

### DIFF
--- a/src/manager/event_handlers.ts
+++ b/src/manager/event_handlers.ts
@@ -24,7 +24,6 @@ import {
     getRoundedCornersCfg,
     getRoundedCornersEffect,
     shouldEnableEffect,
-    unwrapActor,
     updateShadowActorStyle,
     windowScaleFactor,
 } from './utils.js';
@@ -43,7 +42,7 @@ export function onAddEffect(actor: RoundedWindowActor) {
         return;
     }
 
-    unwrapActor(actor)?.add_effect_with_name(
+    actor.get_last_child()?.add_effect_with_name(
         ROUNDED_CORNERS_EFFECT,
         new RoundedCornersEffect(),
     );
@@ -80,7 +79,7 @@ export function onAddEffect(actor: RoundedWindowActor) {
 
 export function onRemoveEffect(actor: RoundedWindowActor): void {
     const name = ROUNDED_CORNERS_EFFECT;
-    unwrapActor(actor)?.remove_effect_by_name(name);
+    actor.get_last_child()?.remove_effect_by_name(name);
 
     // Remove shadow actor
     const shadow = actor.rwcCustomData?.shadow;

--- a/src/manager/event_handlers.ts
+++ b/src/manager/event_handlers.ts
@@ -42,10 +42,12 @@ export function onAddEffect(actor: RoundedWindowActor) {
         return;
     }
 
-    actor.get_last_child()?.add_effect_with_name(
-        ROUNDED_CORNERS_EFFECT,
-        new RoundedCornersEffect(),
-    );
+    actor
+        .get_last_child()
+        ?.add_effect_with_name(
+            ROUNDED_CORNERS_EFFECT,
+            new RoundedCornersEffect(),
+        );
 
     const shadow = createShadow(actor);
 

--- a/src/manager/event_manager.ts
+++ b/src/manager/event_manager.ts
@@ -139,8 +139,9 @@ function applyEffectTo(actor: RoundedWindowActor) {
     // not a bms-application-blurred-widget. This actor is created by BMS and
     // is not the actual window actor.
     const bmsActorName = 'bms-application-blurred-widget';
-    const actorReady = (actor.firstChild && actor.firstChild.name !== bmsActorName) ||
-                       (actor.lastChild && actor.lastChild.name !== bmsActorName);
+    const actorReady =
+        (actor.firstChild && actor.firstChild.name !== bmsActorName) ||
+        (actor.lastChild && actor.lastChild.name !== bmsActorName);
 
     if (!actorReady) {
         const id = actor.connect('child-added', (actor, child) => {

--- a/src/manager/utils.ts
+++ b/src/manager/utils.ts
@@ -19,22 +19,6 @@ import type {RoundedCornersEffect} from '../effect/rounded_corners_effect.js';
 import type {Bounds, RoundedCornerSettings} from '../utils/types.js';
 
 /**
- * Get the actor that rounded corners should be applied to.
- * In Wayland, the effect is applied to WindowActor, but in X11, it is applied
- * to WindowActor.last_child. Usually, there is only one child but to improve the
- * compatibility with Blur My Shell, we use the last child. With Blur My Shell's
- * application blur effect, the first child is actually the blur effect and the
- * second child is the actual window actor.
- *
- * @param actor - The window actor to unwrap.
- * @returns The correct actor that the effect should be applied to.
- */
-export function unwrapActor(actor: Meta.WindowActor): Clutter.Actor | null {
-    const type = actor.metaWindow.get_client_type();
-    return type === Meta.WindowClientType.X11 ? actor.get_last_child() : actor;
-}
-
-/**
  * Get the correct rounded corner setting for a window (custom settings if a
  * window has custom overrides, global settings otherwise).
  *
@@ -70,11 +54,8 @@ type RoundedCornersEffectType = InstanceType<typeof RoundedCornersEffect>;
 export function getRoundedCornersEffect(
     actor: Meta.WindowActor,
 ): RoundedCornersEffectType | null {
-    const win = actor.metaWindow;
     const name = ROUNDED_CORNERS_EFFECT;
-    return win.get_client_type() === Meta.WindowClientType.X11
-        ? (actor.lastChild.get_effect(name) as RoundedCornersEffectType)
-        : (actor.get_effect(name) as RoundedCornersEffectType);
+    return  (actor.lastChild.get_effect(name) as RoundedCornersEffectType);
 }
 
 /**

--- a/src/manager/utils.ts
+++ b/src/manager/utils.ts
@@ -21,14 +21,17 @@ import type {Bounds, RoundedCornerSettings} from '../utils/types.js';
 /**
  * Get the actor that rounded corners should be applied to.
  * In Wayland, the effect is applied to WindowActor, but in X11, it is applied
- * to WindowActor.first_child.
+ * to WindowActor.last_child. Usually, there is only one child but to improve the
+ * compatibility with Blur My Shell, we use the last child. With Blur My Shell's
+ * application blur effect, the first child is actually the blur effect and the
+ * second child is the actual window actor.
  *
  * @param actor - The window actor to unwrap.
  * @returns The correct actor that the effect should be applied to.
  */
 export function unwrapActor(actor: Meta.WindowActor): Clutter.Actor | null {
     const type = actor.metaWindow.get_client_type();
-    return type === Meta.WindowClientType.X11 ? actor.get_first_child() : actor;
+    return type === Meta.WindowClientType.X11 ? actor.get_last_child() : actor;
 }
 
 /**
@@ -70,7 +73,7 @@ export function getRoundedCornersEffect(
     const win = actor.metaWindow;
     const name = ROUNDED_CORNERS_EFFECT;
     return win.get_client_type() === Meta.WindowClientType.X11
-        ? (actor.firstChild.get_effect(name) as RoundedCornersEffectType)
+        ? (actor.lastChild.get_effect(name) as RoundedCornersEffectType)
         : (actor.get_effect(name) as RoundedCornersEffectType);
 }
 

--- a/src/manager/utils.ts
+++ b/src/manager/utils.ts
@@ -55,7 +55,7 @@ export function getRoundedCornersEffect(
     actor: Meta.WindowActor,
 ): RoundedCornersEffectType | null {
     const name = ROUNDED_CORNERS_EFFECT;
-    return  (actor.lastChild.get_effect(name) as RoundedCornersEffectType);
+    return actor.lastChild.get_effect(name) as RoundedCornersEffectType;
 }
 
 /**


### PR DESCRIPTION
This improves the compatibility with Blur-My-Shell. The main problem was that BMS adds an additional child to the `MetaWindowActor`s for the blurred background and RWC applies its effect to that actor instead to the actual window's content.

On X11, the results are pretty good. I think the only remaining issue is that the corners of blurred background are not rounded. But with subtle corner radii this is hardly visible:

![image](https://github.com/user-attachments/assets/af44420b-173a-4312-90c5-d0e51dfcab39)

On Wayland, there are other incompatibility issues which I haven't figured out so far. I am aware that @aunetx [mentioned](https://github.com/aunetx/blur-my-shell/issues/634#issuecomment-2351086715) a fundamental incompatibly, although I do not understand why that is, because the effects are applied to different actors...

**Edit:** Maybe it works now on Wayland as well... see below.