### PR TITLE
Fix Corners Not Removed When Maximised and in Fullscreen

### DIFF
--- a/src/manager/event_manager.ts
+++ b/src/manager/event_manager.ts
@@ -156,6 +156,10 @@ function applyEffectTo(actor: RoundedWindowActor) {
         handlers.onSizeChanged(actor);
     });
 
+    // Get notified about fullscreen explicitly, since a window must not change in
+    // size to go fullscreen
+    connect(actor.metaWindow, 'notify::fullscreen', () => handlers.onSizeChanged(actor));
+    
     // Window focus changed.
     connect(actor.metaWindow, 'notify::appears-focused', () =>
         handlers.onFocusChanged(actor),

--- a/src/manager/utils.ts
+++ b/src/manager/utils.ts
@@ -282,7 +282,7 @@ export function shouldEnableEffect(
     const cfg = getRoundedCornersCfg(win);
     return (
         !(maximized || fullscreen) ||
-        (maximized && cfg.keepRoundedCorners.maximized) ||
+        (maximized && !fullscreen && cfg.keepRoundedCorners.maximized) ||
         (fullscreen && cfg.keepRoundedCorners.fullscreen)
     );
 }


### PR DESCRIPTION
The issue is described in #104.

This issue appears because:
1. A window does not necessarily change in size when going full screen.
2. A window can be both, full screen and maximized.

This PR fixes this by addressing 1. in the event_manager, listening explicitly to the full screen event and 2. by fixing the logic determining whether or not the window should receive rounded corners.