### PR TITLE
[WiP] feat: Support variants of border color for light and dark themes

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.rounded-window-corners-reborn.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.rounded-window-corners-reborn.gschema.xml
@@ -56,7 +56,10 @@
           }&gt;,
           'borderRadius': &lt;uint32 12&gt;,
           'smoothing': &lt;0&gt;,
-          'borderColor': &lt;[0.5, 0.5, 0.5, 1.0]&gt;,
+          'borderColor': &lt;{
+            'light': &lt;[0.5, 0.5, 0.5, 1.0]&gt;,
+            'dark': &lt;[0.5, 0.5, 0.5, 1.0]&gt;
+          }&gt;,
           'enabled': &lt;true&gt;
         }
       </default>

--- a/src/effect/rounded_corners_effect.ts
+++ b/src/effect/rounded_corners_effect.ts
@@ -66,9 +66,10 @@ export const RoundedCornersEffect = GObject.registerClass(
             scaleFactor: number,
             config: RoundedCornerSettings,
             windowBounds: Bounds,
+            borderColorVariant: 'light' | 'dark'
         ) {
             const borderWidth = getPref('border-width') * scaleFactor;
-            const borderColor = config.borderColor;
+            const borderColor = config.borderColor[borderColorVariant];
 
             const outerRadius = config.borderRadius * scaleFactor;
             const {padding, smoothing} = config;

--- a/src/manager/event_handlers.ts
+++ b/src/manager/event_handlers.ts
@@ -31,6 +31,7 @@ import {
 
 import type Meta from 'gi://Meta';
 import type {RoundedWindowActor} from '../utils/types.js';
+import {currentThemeVariant} from '../utils/theme.js';
 
 export function onAddEffect(actor: RoundedWindowActor) {
     logDebug(`Adding effect to ${actor?.metaWindow.title}`);
@@ -154,6 +155,8 @@ export const onFocusChanged = refreshShadow;
 
 export const onSettingsChanged = refreshAllRoundedCorners;
 
+export const onThemeChanged = refreshAllRoundedCorners;
+
 /**
  * Create the shadow actor for a window.
  *
@@ -248,6 +251,7 @@ function refreshRoundedCorners(actor: RoundedWindowActor): void {
         windowScaleFactor(win),
         cfg,
         computeBounds(actor, windowContentOffset),
+        currentThemeVariant(),
     );
 
     // Update BindConstraint for the shadow

--- a/src/manager/event_manager.ts
+++ b/src/manager/event_manager.ts
@@ -6,6 +6,7 @@
 import {logDebug} from '../utils/log.js';
 import {prefs} from '../utils/settings.js';
 import * as handlers from './event_handlers.js';
+import Gio from 'gi://Gio';
 
 import type GObject from 'gi://GObject';
 import type Meta from 'gi://Meta';
@@ -70,6 +71,11 @@ export function enableEffect() {
 
     // When windows are restacked, the order of shadow actors as well.
     connect(global.display, 'restacked', handlers.onRestacked);
+
+    // Listen to system theme (light/dark) changes
+    const interfaceSettings = new Gio.Settings({schema: 'org.gnome.desktop.interface'});
+    connect(interfaceSettings, 'changed::color-scheme', () => handlers.onSettingsChanged());
+    connect(interfaceSettings, 'changed::gtk-theme', () => handlers.onSettingsChanged());
 }
 
 /** Disable the effect for all windows. */

--- a/src/preferences/pages/custom.ts
+++ b/src/preferences/pages/custom.ts
@@ -150,15 +150,18 @@ export const CustomPage = GObject.registerClass(
             });
 
             const color = new Gdk.RGBA();
+            // TODO: 
+            //  - Test.
+            //  - Add support for light/dark theme borderColor
             [color.red, color.green, color.blue, color.alpha] =
-                this.#customWindowSettings[wmClass].borderColor;
+                this.#customWindowSettings[wmClass].borderColor.dark;
 
             r.borderColorButton.set_rgba(color);
             r.borderColorButton.connect(
                 'notify::rgba',
                 (_button: Gtk.ColorDialogButton) => {
                     const color = r.borderColorButton.get_rgba();
-                    this.#customWindowSettings[wmClass].borderColor = [
+                    this.#customWindowSettings[wmClass].borderColor.dark = [
                         color.red,
                         color.green,
                         color.blue,

--- a/src/preferences/pages/general.ts
+++ b/src/preferences/pages/general.ts
@@ -32,7 +32,8 @@ export const GeneralPage = GObject.registerClass(
             'skipLibadwaita',
             'skipLibhandy',
             'borderWidth',
-            'borderColor',
+            'lightBorderColor',
+            'darkBorderColor',
             'cornerRadius',
             'cornerSmoothing',
             'keepForMaximized',
@@ -47,7 +48,8 @@ export const GeneralPage = GObject.registerClass(
         private declare _skipLibadwaita: Adw.SwitchRow;
         private declare _skipLibhandy: Adw.SwitchRow;
         private declare _borderWidth: Gtk.Adjustment;
-        private declare _borderColor: Gtk.ColorDialogButton;
+        private declare _lightBorderColor: Gtk.ColorDialogButton;
+        private declare _darkBorderColor: Gtk.ColorDialogButton;
         private declare _cornerRadius: Gtk.Adjustment;
         private declare _cornerSmoothing: Gtk.Adjustment;
         private declare _keepForMaximized: Adw.SwitchRow;
@@ -83,20 +85,34 @@ export const GeneralPage = GObject.registerClass(
                 Gio.SettingsBindFlags.DEFAULT,
             );
 
-            const color = new Gdk.RGBA();
-            [color.red, color.green, color.blue, color.alpha] =
-                this.#settings.borderColor;
-            this._borderColor.set_rgba(color);
-            this._borderColor.connect(
+            console.log(`[Rounded Window Corners] general `, this.#settings);
+
+            // Set binding for the Light theme border color picker
+            const light = new Gdk.RGBA();
+            
+            [light.red, light.green, light.blue, light.alpha] = this.#settings.borderColor.light;
+            
+            this._lightBorderColor.set_rgba(light);
+            this._lightBorderColor.connect(
                 'notify::rgba',
                 (button: Gtk.ColorDialogButton) => {
-                    const color = button.get_rgba();
-                    this.#settings.borderColor = [
-                        color.red,
-                        color.green,
-                        color.blue,
-                        color.alpha,
-                    ];
+                    const c = button.get_rgba();
+                    this.#settings.borderColor.light = [c.red, c.green, c.blue, c.alpha];
+                    this.#updateGlobalConfig();
+                },
+            );
+
+            // Set binding for the Dark theme border color picker
+            const dark = new Gdk.RGBA();
+
+            [dark.red, dark.green, dark.blue, dark.alpha] = this.#settings.borderColor.dark;
+            
+            this._darkBorderColor.set_rgba(dark);
+            this._darkBorderColor.connect(
+                'notify::rgba',
+                (button: Gtk.ColorDialogButton) => {
+                    const c = button.get_rgba();
+                    this.#settings.borderColor.dark = [c.red, c.green, c.blue, c.alpha];
                     this.#updateGlobalConfig();
                 },
             );

--- a/src/preferences/pages/general.ui
+++ b/src/preferences/pages/general.ui
@@ -54,15 +54,32 @@
         </child>
         <child>
           <object class="AdwActionRow">
-            <property name="title" translatable="yes">Border color</property>
+            <property name="title" translatable="yes">Light theme border color</property>
             <property name="activatable">true</property>
-            <property name="activatable-widget">borderColor</property>
+            <property name="activatable-widget">lightBorderColor</property>
             <child>
-              <object class="GtkColorDialogButton" id="borderColor">
+              <object class="GtkColorDialogButton" id="lightBorderColor">
                 <property name="valign">center</property>
                 <property name="dialog">
                   <object class="GtkColorDialog">
-                    <property name="title" translatable="yes">Border color</property>
+                    <property name="title" translatable="yes">Light theme border color</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Dark theme border color</property>
+            <property name="activatable">true</property>
+            <property name="activatable-widget">darkBorderColor</property>
+            <child>
+              <object class="GtkColorDialogButton" id="darkBorderColor">
+                <property name="valign">center</property>
+                <property name="dialog">
+                  <object class="GtkColorDialog">
+                    <property name="title" translatable="yes">Dark theme border color</property>
                   </object>
                 </property>
               </object>

--- a/src/preferences/pages/reset.ts
+++ b/src/preferences/pages/reset.ts
@@ -54,7 +54,6 @@ export const ResetPage = GObject.registerClass(
             'debug-mode': 'Enable Log',
 
             borderRadius: 'Border Radius',
-            borderColor: 'Border Color',
             padding: 'Padding',
             keepRoundedCorners:
                 'Keep Rounded Corners when Maximized or Fullscreen',

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -7,16 +7,20 @@ import Gtk from 'gi://Gtk';
 
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 import {prefsTabs} from './preferences/index.js';
-import {logDebug} from './utils/log.js';
+import {logDebug, logError} from './utils/log.js';
 import {initPrefs, uninitPrefs} from './utils/settings.js';
 
 export default class RoundedWindowCornersRebornPrefs extends ExtensionPreferences {
     async fillPreferencesWindow(win: Adw.PreferencesWindow) {
-        initPrefs(this.getSettings());
+        try {
+            const settings = this.getSettings();
+            console.log(`[Rounded Window Corners] `, settings);
 
-        for (const page of prefsTabs) {
-            win.add(new page());
-        }
+            initPrefs(settings);
+
+            for (const page of prefsTabs) {
+                win.add(new page());
+            }
 
         // Disconnect all signals when closing the preferences
         win.connect('close-request', () => {
@@ -24,7 +28,11 @@ export default class RoundedWindowCornersRebornPrefs extends ExtensionPreference
             uninitPrefs();
         });
 
-        this.#loadCss();
+            this.#loadCss();
+        } catch (err) {
+            console.error(`[Rounded Window Corners] `, err);
+        }
+        
     }
 
     #loadCss() {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -120,7 +120,7 @@ export function bindPref(
  * @param prefs the GSettings object to clean.
  */
 function resetOutdated(prefs: Gio.Settings) {
-    const lastVersion = 7;
+    const lastVersion = 8;
     const currentVersion = prefs
         .get_user_value('settings-version')
         ?.recursiveUnpack();
@@ -160,16 +160,25 @@ function packRoundedCornerSettings(settings: RoundedCornerSettings) {
     );
     const borderRadius = GLib.Variant.new_uint32(settings.borderRadius);
     const smoothing = GLib.Variant.new_double(settings.smoothing);
-    const borderColor = new GLib.Variant('(dddd)', settings.borderColor);
+
+    // Ensure we always have 4-tuples for RGBA; fallback dark to light if missing
+    const light = settings.borderColor?.light ?? [0.5, 0.5, 0.5, 1.0];
+    const dark = settings.borderColor?.dark ?? light;
+
+    const borderColor = new GLib.Variant('a{sv}', {
+        light: new GLib.Variant('(dddd)', light as [number, number, number, number]),
+        dark: new GLib.Variant('(dddd)', dark as [number, number, number, number]),
+    });
+
     const enabled = GLib.Variant.new_boolean(settings.enabled);
 
     const variantObject = {
-        padding: padding,
-        keepRoundedCorners: keepRoundedCorners,
-        borderRadius: borderRadius,
-        smoothing: smoothing,
-        borderColor: borderColor,
-        enabled: enabled,
+        padding,
+        keepRoundedCorners,
+        borderRadius,
+        smoothing,
+        borderColor,
+        enabled,
     };
 
     return new GLib.Variant('a{sv}', variantObject);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,23 @@
+import Gio from "gi://Gio";
+
+// Determine current theme variant (GNOME 42+ color-scheme or gtk-theme fallback)
+export function currentThemeVariant(): 'dark' | 'light' {
+    try {
+        const settings = new Gio.Settings({schema: 'org.gnome.desktop.interface'});
+        const colorScheme = settings.get_string('color-scheme');
+        
+        if (colorScheme === 'prefer-dark') {
+            return 'dark';
+        }
+
+        const gtkTheme = settings.get_string('gtk-theme');
+        
+        if (gtkTheme && gtkTheme.toLowerCase().includes('dark')) {
+            return 'dark';
+        }
+    } catch (e) {
+        // ignore and fallback to light
+    }
+
+    return 'light';
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,7 +25,10 @@ export type RoundedCornerSettings = {
         top: number;
         bottom: number;
     };
-    borderColor: [number, number, number, number];
+    borderColor: {
+        light: [number, number, number, number],
+        dark: [number, number, number, number],
+    }
     enabled: boolean;
 };
 


### PR DESCRIPTION
Hello!

I'm trying to fix a minor issue with the UI. This PR is not ready to be merged. It is just a demonstration of the issue and the potential solution. Also, it requires further testing, and some refactoring. If you agree to such solution for this problem, I would like to improve the PR further so it can be merged and released.

P.S. I don't have prior experience of coding for Gnome DE, so I'm open to feedback. If you have any suggestions or concerns regarding performance or the code style, please let me know.

## What's the issue?
The extension allows setting a custom border color. The color, will be applied for both light and dark variants of a window. Therefore, it causes minor mismatch in colors. Because a border color suitable for a dark theme might be not suitable for a light theme.

## Example
1. This is a window with custom border color for the dark theme.
<img width="286" height="168" alt="Screenshot from 2025-08-24 17-49-53" src="https://github.com/user-attachments/assets/5a3f0e91-9756-4e27-beae-fcfef49d5d38" />

2. This is how the window's border color looks when the light theme is enabled.
<img width="286" height="168" alt="Screenshot from 2025-08-24 17-49-42" src="https://github.com/user-attachments/assets/8859f755-da49-4549-b406-665222922016" />

3. This is how the light theme's default border color looks.
<img width="286" height="168" alt="Screenshot from 2025-08-24 17-50-16" src="https://github.com/user-attachments/assets/8bf29b32-1fa8-48cd-a44a-8e4a063b732f" />

## Solution
Actually, I see two potential solutions for this issue.

1. Allow a user to set two variants of a border color: the light and the dark one. Then, based on the current theme, apply appropriate color. The PR implements this variant. 
<img width="569" height="295" alt="Screenshot from 2025-08-24 18-04-02" src="https://github.com/user-attachments/assets/66e6cd31-4d85-4929-a0a4-b0d8b9513ef2" />

2. Detect the current theme and somehow extract its default value for border colors. Then just apply the default value.

