### PR TITLE
fix: add guard checks when destroying window

### DIFF
--- a/src/manager/event_manager.ts
+++ b/src/manager/event_manager.ts
@@ -150,9 +150,15 @@ function applyEffectTo(actor: RoundedWindowActor) {
     // that? I have no idea. But without that, weird bugs can happen. For
     // example, when using Dash to Dock, all opened windows will be invisible
     // *unless they are pinned in the dock*. So yeah, GNOME is magic.
-    connect(actor, 'notify::size', () => handlers.onSizeChanged(actor));
+    connect(actor, 'notify::size', () => {
+        if (actor.metaWindow) {
+             handlers.onSizeChanged(actor);
+        }
+    });
     connect(texture, 'size-changed', () => {
-        handlers.onSizeChanged(actor);
+        if (actor.metaWindow) {
+            handlers.onSizeChanged(actor);
+        }
     });
 
     // Get notified about fullscreen explicitly, since a window must not change in


### PR DESCRIPTION
## Description

This PR fixes a race condition that occurs when a window is being destroyed (closed).

Signals like `notify::size`, `size-changed`, `notify::appears-focused` or `workspace-changed` can sometimes fire after the underlying `Meta.Window` object has been cleared, but before the actor is fully disconnected. This results in the extension trying to access properties on a null window object, causing the following error:

```
JS ERROR: TypeError: can't access property "get_client_type", win is null
getRoundedCornersEffect@file:///home/matheus/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn/manager/utils.js:50:5
refreshRoundedCorners@file:///home/matheus/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn/manager/event_handlers.js:164:43
applyEffectTo/<@file:///home/matheus/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn/manager/event_manager.js:119:18
_destroyWindowDone@resource:///org/gnome/shell/ui/windowManager.js:1590:21
onStopped@resource:///org/gnome/shell/ui/windowManager.js:1558:39
_makeEaseCallback/<@resource:///org/gnome/shell/ui/environment.js:66:22
_easeActor/<@resource:///org/gnome/shell/ui/environment.js:161:64
@resource:///org/gnome/shell/ui/init.js:21:20
```

*PS: In the error log above, the crash specifically happened during the `size-changed` signal.*

## Changes

I've added null checks for `actor.metaWindow` within the signal callbacks in `event_manager.ts`. This ensures that the handlers only run if the window still actively exists.