### PR TITLE
fix: prevent SIGABRT crash on GNOME 49 when raising a background window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,78 @@
-![2022-07-29 23-49-57][6]
+# Rounded Window Corners Reborn — GNOME 49 crash fix
 
-<div align="center">
-  <h1>Rounded Window Corners Reborn</h1>
-  <p><i>A GNOME extension that adds rounded corners to all windows</i></p>
-  <a href="https://extensions.gnome.org/extension/7048/rounded-window-corners-reborn">
-    <img src="https://img.shields.io/badge/Install%20from-extensions.gnome.org-4A86CF?style=for-the-badge&logo=Gnome&logoColor=white"/>
-  </a>
-</div>
-<br>
+Fork di [flexagoon/rounded-window-corners](https://github.com/flexagoon/rounded-window-corners) con fix per un crash critico su GNOME 49.
 
-> [!NOTE]
-> This is the fork of the [original rounded-window-corners extension][14] by @yilozt, which is no longer maintained.
+## Il problema
 
-## Features
+Su GNOME Shell 49.x, cliccare sull'icona di un'app già aperta in background (es. Telegram, Materialgram) causava il crash immediato della sessione GNOME con `SIGABRT`.
 
-- Works with Gnome 46+
-- Custom border radius and clip paddings for windows
-- Blocklist for applications that draw their own window decorations
-- Custom shadow for windows with rounded corners
-- Option to skip libadwaita / libhandy application
-- [Superelliptical][1] shape for rounded corners, thanks to [@YuraIz][2]
-- A simple reset preferences dialog
+Il crash avveniva in `libmutter-clutter` durante il paint dell'effetto rounded corners, quando una finestra si trovava in una **transizione di stato** (maximize/restore/raise) con dimensioni temporaneamente pari a zero.
 
-## Installation
-
-### From Gnome Extensions
-
-The extension is available on [extensions.gnome.org](https://extensions.gnome.org). You can install it directly [from here](https://extensions.gnome.org/extension/7048/rounded-window-corners-reborn/), or from the Extension Manager app.
-
-### From pre-built archives
-
-If you want to install the latest commit of the extension, you can get a
-pre-built archive from GitHub Actions.
-
-1. Sign in to GitHub.
-2. Go to [the build action page](https://github.com/flexagoon/rounded-window-corners/actions/workflows/build.yml)
-3. Click on the latest workflow run
-4. Download the extension from the "artifacts" section at the bottom
-5. Install it with the `gnome-extensions install` command
-
-### From source code
-
-1. Install the dependencies:
-    - Node.js
-    - npm
-    - gettext
-    - [just](https://just.systems)
-
-    Those packages are available in the repositories of most linux distros, so
-    you can simply install them with your package manager.
-
-2. Build the extension
-
-    ```bash
-    git clone https://github.com/flexagoon/rounded-window-corners
-    cd rounded-window-corners
-    just install
-    ```
-
-After this, the extension will be installed to
-`~/.local/share/gnome-shell/extensions`.
-
-### From unofficial AUR packages on Arch Linux
-
-If you use Arch, by the way, you can also install from the provided [AUR](https://aur.archlinux.org/) packages using [paru](https://github.com/Morganamilo/paru) or [yay](https://github.com/Jguer/yay). Two packages are available:
-
-- [gnome-shell-extension-rounded-window-corners-reborn](https://aur.archlinux.org/packages/gnome-shell-extension-rounded-window-corners-reborn) uses the pre-build archives
-- [gnome-shell-extension-rounded-window-corners-reborn-git](https://aur.archlinux.org/packages/gnome-shell-extension-rounded-window-corners-reborn-git) builds on your machine
-
-Installation:
-
-```zsh
-paru gnome-shell-extension-rounded-window-corners-reborn
+Stack trace del crash:
+```
+g_assertion_message_expr (libglib-2.0.so.0)
+  → libmutter-clutter-17.so.0 (clutter_actor_continue_paint)
+  → clutter_paint_node_paint
+  → clutter_actor_paint
+  → meta_window_actor_paint_to_content (libmutter-17.so.0)
+  → GJS / JavaScript callback
 ```
 
-Note these packages are not official.
+## Fix applicati
 
-## Translation
+### 1. `effect/rounded_corners_effect.js` — crash principale
 
-You can help with the translation of the extension by submitting translations
-on [Weblate](https://hosted.weblate.org/engage/rounded-window-corners-reborn)
+**Problema**: `vfunc_paint_target` veniva chiamato con l'attore a dimensioni 0x0, causando un'assertion failure in Clutter (`width > 0 && height > 0`). Inoltre `updateUniforms` calcolava `1 / width` e `1 / height` con divisione per zero, e usava `bounds[4]` (fuori bounds, sempre `undefined`).
 
-[![Translation status](https://hosted.weblate.org/widget/rounded-window-corners-reborn/multi-auto.svg)](https://hosted.weblate.org/engage/rounded-window-corners-reborn/)
+**Fix**:
+- Aggiunto override di `vfunc_paint_target` con guardia sulle dimensioni
+- Aggiunta guardia in `updateUniforms` sulle dimensioni prima di procedere
+- Corretta divisione per zero in `pixelStep`
+- Corretto indice `bounds[4]` → `bounds[3]` nel calcolo di `maxRadius`
 
-You can also manually edit .po files and submit a PR if you know how to do that.
+### 2. `manager/utils.js` — null safety
 
-## Development
+**Problema**: `unwrapActor()` e `getRoundedCornersEffect()` accedevano a `actor.metaWindow.get_client_type()` senza verificare che `metaWindow` non fosse `null`, causando errori JS visibili nei log.
 
-Here are the avaliable `just` commands (run `just --list` to see this message):
+**Fix**: Aggiunto controllo `if (!actor?.metaWindow) return null` in entrambe le funzioni.
+
+### 3. `manager/event_handlers.js` — null safety
+
+**Problema**: `onAddEffect()`, `refreshShadow()` e `refreshRoundedCorners()` usavano `actor.metaWindow` senza null check, portando a `TypeError: can't access property "get_client_type", win is null` nei log di GNOME Shell.
+
+**Fix**: Aggiunto `if (!win) return` all'inizio di ciascuna funzione dopo aver letto `actor?.metaWindow`.
+
+## Versioni interessate
+
+- GNOME Shell **49.x** (confermato su 49.5)
+- Estensione versione **14** (`rounded-window-corners@fxgn`)
+- Distribuzione testata: **CachyOS** (Arch-based)
+
+## Installazione manuale
 
 ```bash
-Available recipes:
-    build   # Compile the extension and all resources
-    clean   # Delete the build directory
-    install # Build and install the extension from source
-    pack    # Build and pack the extension
-    pot     # Update and compile the translation files
+# Backup dell'estensione originale
+cp -r ~/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn \
+      ~/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn.bak
+
+# Clona questo fork
+git clone https://github.com/TUO_USERNAME/rounded-window-corners.git
+cd rounded-window-corners
+
+# Copia i file patchati
+cp effect/rounded_corners_effect.js \
+   manager/utils.js \
+   manager/event_handlers.js \
+   ~/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn/effect/
+cp manager/utils.js manager/event_handlers.js \
+   ~/.local/share/gnome-shell/extensions/rounded-window-corners@fxgn/manager/
+
+# Ricarica l'estensione
+gnome-extensions disable rounded-window-corners@fxgn
+gnome-extensions enable rounded-window-corners@fxgn
 ```
 
-## Credits
+## Upstream
 
-Thanks to [yotamguttman](https://github.com/yotamguttman) for making an icon for the extension!
-
-<!-- links -->
-
-[1]: https://en.wikipedia.org/wiki/Superellipse
-[2]: https://github.com/YuraIz
-[3]: https://extensions.gnome.org/extension/3740/compiz-alike-magic-lamp-effect/
-[4]: https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/compositor/meta-background-content.c#L138
-[6]: https://user-images.githubusercontent.com/32430186/181902857-d4d10740-82fe-4941-b064-d436b9ea7317.png
-[7]: https://extensions.gnome.org/extension/5237/rounded-window-corners/
-[8]: https://github.com/yilozt/rounded-window-corners/releases
-[9]: https://github.com/yilozt/rounded-window-corners/actions/workflows/pack.yml
-[10]: https://img.shields.io/github/v/release/yilozt/rounded-window-corners?style=flat-square
-[11]: https://img.shields.io/github/actions/workflow/status/yilozt/rounded-window-corners/pack.yml?branch=main&style=flat-square
-[12]: https://hosted.weblate.org/widgets/rounded-window-corners/-/rounded-window-corners/multi-auto.svg
-[13]: https://hosted.weblate.org/engage/rounded-window-corners/
-[14]: https://github.com/yilozt/rounded-window-corners
+Il fix è stato sviluppato analizzando i coredump prodotti dal crash. Si raccomanda di aprire una PR sul repository originale:
+[https://github.com/flexagoon/rounded-window-corners](https://github.com/flexagoon/rounded-window-corners)

--- a/effect/rounded_corners_effect.js
+++ b/effect/rounded_corners_effect.js
@@ -1,0 +1,108 @@
+/** @file Binds the actual corner rounding shader to the windows. */
+var _a;
+import Cogl from 'gi://Cogl';
+import GObject from 'gi://GObject';
+import Shell from 'gi://Shell';
+import { readShader } from '../utils/file.js';
+import { getPref } from '../utils/settings.js';
+const [declarations, code] = readShader(import.meta.url, 'shader/rounded_corners.frag');
+class Uniforms {
+    bounds = 0;
+    clipRadius = 0;
+    borderWidth = 0;
+    borderColor = 0;
+    borderedAreaBounds = 0;
+    borderedAreaClipRadius = 0;
+    exponent = 0;
+    pixelStep = 0;
+}
+export const RoundedCornersEffect = GObject.registerClass({}, class Effect extends Shell.GLSLEffect {
+    /**
+     * To store a uniform value, we need to know its location in the shader,
+     * which is done by calling `this.get_uniform_location()`. This is
+     * expensive, so we cache the location of uniforms when the shader is
+     * created.
+     */
+    static uniforms = new Uniforms();
+    constructor() {
+        super();
+        for (const k in Effect.uniforms) {
+            Effect.uniforms[k] =
+                this.get_uniform_location(k);
+        }
+    }
+    vfunc_build_pipeline() {
+        this.add_glsl_snippet(Cogl.SnippetHook.FRAGMENT, declarations, code, false);
+    }
+    /**
+     * Update uniforms of the shader.
+     * For more information, see the comments in the shader file.
+     *
+     * @param scaleFactor - Desktop scaling factor
+     * @param config - Rounded corners configuration
+     * @param windowBounds - Bounds of the window without padding
+     */
+    vfunc_paint_target(paintNode, paintContext) {
+        const actor = this.actor;
+        if (!actor || actor.get_width() <= 0 || actor.get_height() <= 0) {
+            return;
+        }
+        super.vfunc_paint_target(paintNode, paintContext);
+    }
+    updateUniforms(scaleFactor, config, windowBounds) {
+        const width = this.actor?.get_width() ?? 0;
+        const height = this.actor?.get_height() ?? 0;
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+        const borderWidth = getPref('border-width') * scaleFactor;
+        const borderColor = config.borderColor;
+        const outerRadius = config.borderRadius * scaleFactor;
+        const { padding, smoothing } = config;
+        const bounds = [
+            windowBounds.x1 + padding.left * scaleFactor,
+            windowBounds.y1 + padding.top * scaleFactor,
+            windowBounds.x2 - padding.right * scaleFactor,
+            windowBounds.y2 - padding.bottom * scaleFactor,
+        ];
+        const borderedAreaBounds = [
+            bounds[0] + borderWidth,
+            bounds[1] + borderWidth,
+            bounds[2] - borderWidth,
+            bounds[3] - borderWidth,
+        ];
+        let borderedAreaRadius = outerRadius - borderWidth;
+        if (borderedAreaRadius < 0.001) {
+            borderedAreaRadius = 0.0;
+        }
+        const pixelStep = [
+            1 / width,
+            1 / height,
+        ];
+        // This is needed for squircle corners
+        let exponent = smoothing * 10 + 2;
+        let radius = outerRadius * 0.5 * exponent;
+        // Fix: was bounds[4] (undefined), should be bounds[3]
+        const maxRadius = Math.min(bounds[2] - bounds[0], bounds[3] - bounds[1]);
+        if (radius > maxRadius) {
+            exponent *= maxRadius / radius;
+            radius = maxRadius;
+        }
+        borderedAreaRadius *= radius / outerRadius;
+        this.#setUniforms(bounds, radius, borderWidth, borderColor, borderedAreaBounds, borderedAreaRadius, pixelStep, exponent);
+    }
+    #setUniforms(bounds, radius, borderWidth, borderColor, borderedAreaBounds, borderedAreaRadius, pixelStep, exponent) {
+        const uniforms = Effect.uniforms;
+        this.set_uniform_float(uniforms.bounds, 4, bounds);
+        this.set_uniform_float(uniforms.clipRadius, 1, [radius]);
+        this.set_uniform_float(uniforms.borderWidth, 1, [borderWidth]);
+        this.set_uniform_float(uniforms.borderColor, 4, borderColor);
+        this.set_uniform_float(uniforms.borderedAreaBounds, 4, borderedAreaBounds);
+        this.set_uniform_float(uniforms.borderedAreaClipRadius, 1, [
+            borderedAreaRadius,
+        ]);
+        this.set_uniform_float(uniforms.pixelStep, 2, pixelStep);
+        this.set_uniform_float(uniforms.exponent, 1, [exponent]);
+        this.queue_repaint();
+    }
+});

--- a/manager/event_handlers.js
+++ b/manager/event_handlers.js
@@ -1,0 +1,218 @@
+/**
+ * @file Contains the implementation of handlers for various events that need
+ * to be processed by the extension. Those handlers are bound to event signals
+ * in effect_manager.ts.
+ */
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import { ClipShadowEffect } from '../effect/clip_shadow_effect.js';
+import { RoundedCornersEffect } from '../effect/rounded_corners_effect.js';
+import { CLIP_SHADOW_EFFECT, ROUNDED_CORNERS_EFFECT, } from '../utils/constants.js';
+import { logDebug } from '../utils/log.js';
+import { getPref } from '../utils/settings.js';
+import { computeBounds, computeShadowActorOffset, computeWindowContentsOffset, getRoundedCornersCfg, getRoundedCornersEffect, shouldEnableEffect, unwrapActor, updateShadowActorStyle, windowScaleFactor, } from './utils.js';
+export function onAddEffect(actor) {
+    const win = actor?.metaWindow;
+    if (!win) {
+        return;
+    }
+    logDebug(`Adding effect to ${win.title}`);
+    if (!shouldEnableEffect(win)) {
+        logDebug(`Skipping ${win.title}`);
+        return;
+    }
+    unwrapActor(actor)?.add_effect_with_name(ROUNDED_CORNERS_EFFECT, new RoundedCornersEffect());
+    const shadow = createShadow(actor);
+    // Bind properties of the window to the shadow actor.
+    const propertyBindings = [];
+    for (const prop of [
+        'pivot-point',
+        'translation-x',
+        'translation-y',
+        'scale-x',
+        'scale-y',
+        'visible',
+    ]) {
+        const binding = actor.bind_property(prop, shadow, prop, GObject.BindingFlags.SYNC_CREATE);
+        propertyBindings.push(binding);
+    }
+    // Store shadow, app type, visible binding, so that we can access them later
+    actor.rwcCustomData = {
+        shadow,
+        unminimizedTimeoutId: 0,
+        propertyBindings,
+    };
+    // Make sure the effect is applied correctly.
+    refreshRoundedCorners(actor);
+}
+export function onRemoveEffect(actor) {
+    const name = ROUNDED_CORNERS_EFFECT;
+    unwrapActor(actor)?.remove_effect_by_name(name);
+    // Unbind all properties
+    for (const binding of actor.rwcCustomData?.propertyBindings || []) {
+        binding.unbind();
+    }
+    // Remove shadow actor
+    const shadow = actor.rwcCustomData?.shadow;
+    if (shadow) {
+        shadow.get_constraints().forEach(constraint => {
+            shadow.remove_constraint(constraint);
+        });
+        global.windowGroup.remove_child(shadow);
+        shadow.clear_effects();
+        shadow.destroy();
+    }
+    // Remove all timeout handler
+    const timeoutId = actor.rwcCustomData?.unminimizedTimeoutId;
+    if (timeoutId) {
+        GLib.source_remove(timeoutId);
+    }
+    delete actor.rwcCustomData;
+}
+export function onMinimize(actor) {
+    // Compatibility with "Compiz alike magic lamp effect".
+    // When minimizing a window, disable the shadow to make the magic lamp effect
+    // work.
+    const magicLampEffect = actor.get_effect('minimize-magic-lamp-effect');
+    const shadow = actor.rwcCustomData?.shadow;
+    const roundedCornersEffect = getRoundedCornersEffect(actor);
+    if (magicLampEffect && shadow && roundedCornersEffect) {
+        logDebug('Minimizing with magic lamp effect');
+        shadow.visible = false;
+        roundedCornersEffect.enabled = false;
+    }
+}
+export function onUnminimize(actor) {
+    // Compatibility with "Compiz alike magic lamp effect".
+    // When unminimizing a window, wait until the effect is completed before
+    // showing the shadow.
+    const magicLampEffect = actor.get_effect('unminimize-magic-lamp-effect');
+    const shadow = actor.rwcCustomData?.shadow;
+    const roundedCornersEffect = getRoundedCornersEffect(actor);
+    if (magicLampEffect && shadow && roundedCornersEffect) {
+        shadow.visible = false;
+        const timer = magicLampEffect.timerId;
+        const id = timer.connect('new-frame', source => {
+            // Wait until the effect is 98% completed
+            if (source.get_progress() > 0.98) {
+                logDebug('Unminimizing with magic lamp effect');
+                shadow.visible = true;
+                roundedCornersEffect.enabled = true;
+                source.disconnect(id);
+            }
+        });
+        return;
+    }
+}
+export function onRestacked() {
+    for (const actor of global.get_window_actors()) {
+        const shadow = actor.rwcCustomData?.shadow;
+        if (!(actor.visible && shadow)) {
+            continue;
+        }
+        global.windowGroup.set_child_below_sibling(shadow, actor);
+    }
+}
+export const onSizeChanged = refreshRoundedCorners;
+export const onFocusChanged = refreshShadow;
+export const onSettingsChanged = refreshAllRoundedCorners;
+/**
+ * Create the shadow actor for a window.
+ *
+ * @param actor - The window actor to create the shadow actor for.
+ */
+function createShadow(actor) {
+    const shadow = new St.Bin({
+        name: 'Shadow Actor',
+        child: new St.Bin({
+            xExpand: true,
+            yExpand: true,
+        }),
+    });
+    shadow.firstChild.add_style_class_name('shadow');
+    refreshShadow(actor);
+    // We have to clip the shadow because of this issue:
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/4474
+    shadow.add_effect_with_name(CLIP_SHADOW_EFFECT, new ClipShadowEffect());
+    // Draw the shadow actor below the window actor.
+    global.windowGroup.insert_child_below(shadow, actor);
+    // Bind position and size between window and shadow
+    for (let i = 0; i < 4; i++) {
+        const constraint = new Clutter.BindConstraint({
+            source: actor,
+            coordinate: i,
+            offset: 0,
+        });
+        shadow.add_constraint(constraint);
+    }
+    return shadow;
+}
+/**
+ * Refresh the shadow actor for a window.
+ *
+ * @param actor - The window actor to refresh the shadow for.
+ */
+function refreshShadow(actor) {
+    const win = actor?.metaWindow;
+    if (!win) {
+        return;
+    }
+    const shadow = actor.rwcCustomData?.shadow;
+    if (!shadow) {
+        return;
+    }
+    const shadowSettings = win.appears_focused
+        ? getPref('focused-shadow')
+        : getPref('unfocused-shadow');
+    const { borderRadius, padding } = getRoundedCornersCfg(win);
+    updateShadowActorStyle(win, shadow, borderRadius, shadowSettings, padding);
+}
+/**
+ * Refresh rounded corners state and settings for a window.
+ *
+ * @param actor - The window actor to refresh the rounded corners settings for.
+ */
+function refreshRoundedCorners(actor) {
+    const win = actor?.metaWindow;
+    if (!win) {
+        return;
+    }
+    const windowInfo = actor.rwcCustomData;
+    const effect = getRoundedCornersEffect(actor);
+    const hasEffect = effect && windowInfo;
+    const shouldHaveEffect = shouldEnableEffect(win);
+    if (!hasEffect) {
+        // onAddEffect already skips windows that shouldn't have rounded corners.
+        onAddEffect(actor);
+        return;
+    }
+    if (!shouldHaveEffect) {
+        onRemoveEffect(actor);
+        return;
+    }
+    if (!effect.enabled) {
+        effect.enabled = true;
+    }
+    // When window size is changed, update uniforms for corner rounding shader.
+    const cfg = getRoundedCornersCfg(win);
+    const windowContentOffset = computeWindowContentsOffset(win);
+    effect.updateUniforms(windowScaleFactor(win), cfg, computeBounds(actor, windowContentOffset));
+    // Update BindConstraint for the shadow
+    const shadow = windowInfo.shadow;
+    const offsets = computeShadowActorOffset(actor, windowContentOffset);
+    const constraints = shadow.get_constraints();
+    constraints.forEach((constraint, i) => {
+        if (constraint instanceof Clutter.BindConstraint) {
+            constraint.offset = offsets[i];
+        }
+    });
+    refreshShadow(actor);
+}
+/** Refresh rounded corners settings for all windows. */
+function refreshAllRoundedCorners() {
+    for (const actor of global.get_window_actors()) {
+        refreshRoundedCorners(actor);
+    }
+}

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -1,0 +1,289 @@
+/** @file Provides various utility functions used withing signal handling code. */
+import Gio from 'gi://Gio';
+import Meta from 'gi://Meta';
+import St from 'gi://St';
+import { boxShadowCss } from '../utils/box_shadow.js';
+import { APP_SHADOWS, ROUNDED_CORNERS_EFFECT, SHADOW_PADDING, } from '../utils/constants.js';
+import { readFile } from '../utils/file.js';
+import { logDebug } from '../utils/log.js';
+import { getPref } from '../utils/settings.js';
+// Cache mutter settings to avoid creating a new Gio.Settings object on every
+// call to windowScaleFactor (which is called per-frame during overview animations).
+let mutterSettings = null;
+let fractionalScalingEnabled = null;
+/**
+ * Check whether fractional scaling is enabled in the GNOME mutter settings.
+ * The result is cached and invalidated when the `experimental-features` setting
+ * changes.
+ *
+ * @returns Whether fractional scaling is currently enabled.
+ */
+function isFractionalScalingEnabled() {
+    if (mutterSettings === null) {
+        mutterSettings = Gio.Settings.new('org.gnome.mutter');
+        mutterSettings.connect('changed::experimental-features', () => {
+            fractionalScalingEnabled = null;
+        });
+    }
+    if (fractionalScalingEnabled === null) {
+        const features = mutterSettings.get_strv('experimental-features');
+        // The method doesn't exist on GNOME 50+ because it's Wayland-only
+        const isWaylandCompositor = !Meta.is_wayland_compositor || Meta.is_wayland_compositor();
+        fractionalScalingEnabled =
+            isWaylandCompositor &&
+                features.includes('scale-monitor-framebuffer');
+    }
+    return fractionalScalingEnabled;
+}
+/**
+ * Clear the cached mutter settings and fractional scaling state.
+ * Should be called when the extension is disabled to release the
+ * {@link Gio.Settings} object and its D-Bus signal subscription.
+ */
+export function clearMutterSettingsCache() {
+    mutterSettings = null;
+    fractionalScalingEnabled = null;
+}
+/**
+ * Get the actor that rounded corners should be applied to.
+ * In Wayland, the effect is applied to WindowActor, but in X11, it is applied
+ * to WindowActor.first_child.
+ *
+ * @param actor - The window actor to unwrap.
+ * @returns The correct actor that the effect should be applied to.
+ */
+export function unwrapActor(actor) {
+    const win = actor?.metaWindow;
+    if (!win) {
+        return null;
+    }
+    const type = win.get_client_type();
+    return type === Meta.WindowClientType.X11 ? actor.get_first_child() : actor;
+}
+/**
+ * Get the correct rounded corner setting for a window (custom settings if a
+ * window has custom overrides, global settings otherwise).
+ *
+ * @param win - The window to get the settings for.
+ * @returns The matching settings object.
+ */
+export function getRoundedCornersCfg(win) {
+    const globalCfg = getPref('global-rounded-corner-settings');
+    const customCfgList = getPref('custom-rounded-corner-settings');
+    const wmClass = win.get_wm_class_instance();
+    if (wmClass == null ||
+        !customCfgList[wmClass] ||
+        !customCfgList[wmClass].enabled) {
+        return globalCfg;
+    }
+    return customCfgList[wmClass];
+}
+/**
+ * Get the Clutter.Effect object for the rounded corner effect of a specific
+ * window.
+ *
+ * @param actor - The window actor to get the effect for.
+ * @returns The corresponding Clutter.Effect object.
+ */
+export function getRoundedCornersEffect(actor) {
+    const win = actor?.metaWindow;
+    if (!win) {
+        return null;
+    }
+    const name = ROUNDED_CORNERS_EFFECT;
+    return win.get_client_type() === Meta.WindowClientType.X11
+        ? actor.firstChild?.get_effect(name) ?? null
+        : actor.get_effect(name);
+}
+/**
+ * Get the scaling factor of a window.
+ *
+ * @param win - The window to get the scaling factor for.
+ * @returns The scaling factor of the window.
+ */
+export function windowScaleFactor(win) {
+    // When fractional scaling is enabled, always return 1.
+    // Use cached settings to avoid creating a new Gio.Settings object per call.
+    if (isFractionalScalingEnabled()) {
+        return 1;
+    }
+    const monitorIndex = win.get_monitor();
+    return global.display.get_monitor_scale(monitorIndex);
+}
+/** Compute outer bounds for rounded corners of a window
+ *
+ * @param actor - The window actor to compute the bounds for.
+ * @param [x, y, width, height] - The content offsets of the window actor.
+ */
+export function computeBounds(actor, [x, y, width, height]) {
+    const bounds = {
+        x1: x + 1,
+        y1: y + 1,
+        x2: x + actor.width + width,
+        y2: y + actor.height + height,
+    };
+    // Kitty draws its window decoration by itself, so we need to manually
+    // clip its shadow and recompute the outer bounds for it.
+    if (getPref('tweak-kitty-terminal') &&
+        actor.metaWindow.get_client_type() === Meta.WindowClientType.WAYLAND &&
+        actor.metaWindow.get_wm_class_instance() === 'kitty') {
+        const [x1, y1, x2, y2] = APP_SHADOWS.kitty;
+        const scale = windowScaleFactor(actor.metaWindow);
+        bounds.x1 += x1 * scale;
+        bounds.y1 += y1 * scale;
+        bounds.x2 -= x2 * scale;
+        bounds.y2 -= y2 * scale;
+    }
+    return bounds;
+}
+/**
+ * Compute the offset of actual window contents from the entire window buffer.
+ *
+ * @param window - The window to compute the offset for.
+ * @returns The content offsets of the window (x, y, width, height).
+ */
+export function computeWindowContentsOffset(window) {
+    const bufferRect = window.get_buffer_rect();
+    const frameRect = window.get_frame_rect();
+    return [
+        frameRect.x - bufferRect.x,
+        frameRect.y - bufferRect.y,
+        frameRect.width - bufferRect.width,
+        frameRect.height - bufferRect.height,
+    ];
+}
+/**
+ * Compute the offset of the shadow actor for a window.
+ *
+ * @param actor - The window actor to compute the offset for.
+ * @param [offsetX, offsetY, offsetWidth, offsetHeight] - The content offsets of the window actor.
+ */
+export function computeShadowActorOffset(actor, [offsetX, offsetY, offsetWidth, offsetHeight]) {
+    const win = actor.metaWindow;
+    const shadowPadding = SHADOW_PADDING * windowScaleFactor(win);
+    return [
+        offsetX - shadowPadding,
+        offsetY - shadowPadding,
+        2 * shadowPadding + offsetWidth,
+        2 * shadowPadding + offsetHeight,
+    ];
+}
+/** Update the CSS style of a shadow actor
+ *
+ * @param win - The window to update the style for.
+ * @param actor - The shadow actor to update the style for.
+ * @param borderRadius - The border radius of the shadow actor.
+ * @param shadow - The shadow settings for the window.
+ * @param padding - The padding of the shadow actor.
+ */
+export function updateShadowActorStyle(win, actor, borderRadius = getPref('global-rounded-corner-settings').borderRadius, shadow = getPref('focused-shadow'), padding = getPref('global-rounded-corner-settings').padding) {
+    const { left, right, top, bottom } = padding;
+    // Increase border_radius when smoothing is on.
+    // Read global settings once to avoid repeated GSettings deserializations.
+    let adjustedBorderRadius = borderRadius;
+    const globalCfg = getPref('global-rounded-corner-settings');
+    if (globalCfg !== null) {
+        adjustedBorderRadius *= 1.0 + globalCfg.smoothing;
+    }
+    // If there are two monitors with different scale factors, the scale of
+    // the window may be different from the scale that has to be applied in
+    // the css, so we have to adjust the scale factor accordingly.
+    const originalScale = St.ThemeContext.get_for_stage(global.stage).scaleFactor;
+    const scale = windowScaleFactor(win) / originalScale;
+    actor.style = `padding: ${SHADOW_PADDING * scale}px;`;
+    const child = actor.firstChild;
+    const hideShadowForMaximizedFullscreen = !getPref('keep-shadow-for-maximized-fullscreen') &&
+        (win.maximizedHorizontally ||
+            win.maximizedVertically ||
+            win.fullscreen);
+    const newChildStyle = hideShadowForMaximizedFullscreen
+        ? 'opacity: 0;'
+        : `background: white;
+               border-radius: ${adjustedBorderRadius * scale}px;
+               ${boxShadowCss(shadow, scale)};
+               margin: ${top * scale}px
+                       ${right * scale}px
+                       ${bottom * scale}px
+                       ${left * scale}px;`;
+    // Only update style and queue a redraw when the style actually changed.
+    if (child.style !== newChildStyle) {
+        child.style = newChildStyle;
+        child.queue_redraw();
+    }
+}
+/**
+ * Check whether a window should have rounded corners.
+ *
+ * @param win - The window to check.
+ * @returns Whether the window should have rounded corners.
+ */
+export function shouldEnableEffect(win) {
+    // Skip rounded corners for the DING (Desktop Icons NG) extension.
+    //
+    // https://extensions.gnome.org/extension/2087/desktop-icons-ng-ding/
+    if (win.gtkApplicationId === 'com.rastersoft.ding') {
+        return false;
+    }
+    // Skip blacklisted applications.
+    const wmClass = win.get_wm_class_instance();
+    if (wmClass == null) {
+        logDebug(`Warning: wm_class_instance of ${win}: ${win.title} is null`);
+        return false;
+    }
+    // handles blacklist / whitelist
+    const isException = getPref('blacklist').includes(wmClass);
+    const enableExceptions = getPref('whitelist');
+    if (isException !== enableExceptions) {
+        return false;
+    }
+    // Only apply the effect to normal windows (skip menus, tooltips, etc.)
+    if (win.windowType !== Meta.WindowType.NORMAL &&
+        win.windowType !== Meta.WindowType.DIALOG &&
+        win.windowType !== Meta.WindowType.MODAL_DIALOG) {
+        return false;
+    }
+    // Skip libhandy/libadwaita applications according to settings.
+    const appType = win._appType ?? getAppType(win);
+    win._appType = appType; // Cache the result.
+    logDebug(`Check Type of window:${win.title} => ${appType}`);
+    if (getPref('skip-libadwaita-app') &&
+        appType === 'LibAdwaita' &&
+        !isException) {
+        return false;
+    }
+    if (getPref('skip-libhandy-app') &&
+        appType === 'LibHandy' &&
+        !isException) {
+        return false;
+    }
+    // Skip maximized/fullscreen windows according to settings.
+    const maximized = win.maximizedHorizontally || win.maximizedVertically;
+    const fullscreen = win.fullscreen;
+    const cfg = getRoundedCornersCfg(win);
+    return (!(maximized || fullscreen) ||
+        (maximized && !fullscreen && cfg.keepRoundedCorners.maximized) ||
+        (fullscreen && cfg.keepRoundedCorners.fullscreen));
+}
+/**
+ * Get the type of the application (LibHandy/LibAdwaita/Other).
+ *
+ * @param win - The window to get the type of.
+ * @returns the type of the application.
+ */
+function getAppType(win) {
+    try {
+        // May throw a permission error.
+        const contents = readFile(`/proc/${win.get_pid()}/maps`);
+        if (contents.includes('libhandy-1.so')) {
+            return 'LibHandy';
+        }
+        if (contents.includes('libadwaita-1.so')) {
+            return 'LibAdwaita';
+        }
+        return 'Other';
+    }
+    catch (e) {
+        logError(e);
+        return 'Other';
+    }
+}


### PR DESCRIPTION
sorry made a mistake, I really didn't want to pollute the log