### PR TITLE
Add support for Gnome 50 and fix Wayland compositor check

### DIFF
--- a/src/manager/utils.ts
+++ b/src/manager/utils.ts
@@ -22,6 +22,8 @@ import {getPref} from '../utils/settings.js';
 // call to windowScaleFactor (which is called per-frame during overview animations).
 let mutterSettings: Gio.Settings | null = null;
 let fractionalScalingEnabled: boolean | null = null;
+// Gnome 50 support
+let isWaylandCompositor = !Meta.is_wayland_compositor || Meta.is_wayland_compositor();
 
 /**
  * Check whether fractional scaling is enabled in the GNOME mutter settings.


### PR DESCRIPTION
Adding 
`let isWaylandCompositor = !Meta.is_wayland_compositor || Meta.is_wayland_compositor();` 
before solves:
`TypeError: (intermediate value).is_wayland_compositor is not a function`