### PR TITLE
fix: guard rounded corner updates during window destroy

### DIFF
--- a/src/manager/event_handlers.ts
+++ b/src/manager/event_handlers.ts
@@ -32,9 +32,12 @@ import {
 } from './utils.js';
 
 export function onAddEffect(actor: RoundedWindowActor) {
-    logDebug(`Adding effect to ${actor?.metaWindow.title}`);
-
     const win = actor.metaWindow;
+    if (!win) {
+        return;
+    }
+
+    logDebug(`Adding effect to ${win.title}`);
 
     // Skip windows that already have the effect to prevent a memory leak
     const windowInfo = actor.rwcCustomData;
@@ -213,6 +216,10 @@ function createShadow(actor: Meta.WindowActor): St.Bin {
  */
 function refreshShadow(actor: RoundedWindowActor) {
     const win = actor.metaWindow;
+    if (!win) {
+        return;
+    }
+
     const shadow = actor.rwcCustomData?.shadow;
     if (!shadow) {
         return;
@@ -234,6 +241,10 @@ function refreshShadow(actor: RoundedWindowActor) {
  */
 function refreshRoundedCorners(actor: RoundedWindowActor): void {
     const win = actor.metaWindow;
+    if (!win) {
+        onRemoveEffect(actor);
+        return;
+    }
 
     const windowInfo = actor.rwcCustomData;
     const effect = getRoundedCornersEffect(actor);

--- a/src/manager/event_manager.ts
+++ b/src/manager/event_manager.ts
@@ -136,14 +136,25 @@ function disconnectAll(object?: GObject.Object) {
  * @param actor - The window actor to apply the effect to.
  */
 function applyEffectTo(actor: RoundedWindowActor) {
+    if (!actor?.metaWindow) {
+        return;
+    }
+
     // In wayland sessions, the surface actor of XWayland clients is sometimes
     // not ready when the window is created. In this case, we wait until it is
     // ready before applying the effect.
     if (!actor.firstChild) {
-        const id = actor.connect('notify::first-child', () => {
-            applyEffectTo(actor);
-            actor.disconnect(id);
-        });
+        if (!actor.rwcWaitingForFirstChild) {
+            connect(actor, 'notify::first-child', () => {
+                if (!actor.firstChild) {
+                    return;
+                }
+
+                actor.rwcWaitingForFirstChild = false;
+                applyEffectTo(actor);
+            });
+            actor.rwcWaitingForFirstChild = true;
+        }
 
         return;
     }
@@ -153,44 +164,49 @@ function applyEffectTo(actor: RoundedWindowActor) {
         return;
     }
 
-    // Window resized.
-    //
-    // The signal has to be connected both to the actor and the texture. Why is
-    // that? I have no idea. But without that, weird bugs can happen. For
-    // example, when using Dash to Dock, all opened windows will be invisible
-    // *unless they are pinned in the dock*. So yeah, GNOME is magic.
-    connect(actor, 'notify::size', () => {
-        if (actor.metaWindow) {
-            handlers.onSizeChanged(actor);
-        }
-    });
-    connect(texture, 'size-changed', () => {
-        if (actor.metaWindow) {
-            handlers.onSizeChanged(actor);
-        }
-    });
+    if (!actor.rwcSignalsConnected) {
+        // Window resized.
+        //
+        // The signal has to be connected both to the actor and the texture. Why is
+        // that? I have no idea. But without that, weird bugs can happen. For
+        // example, when using Dash to Dock, all opened windows will be invisible
+        // *unless they are pinned in the dock*. So yeah, GNOME is magic.
+        connect(actor, 'notify::size', () => {
+            if (actor.metaWindow) {
+                handlers.onSizeChanged(actor);
+            }
+        });
+        connect(texture, 'size-changed', () => {
+            if (actor.metaWindow) {
+                handlers.onSizeChanged(actor);
+            }
+        });
 
-    // Get notified about fullscreen explicitly, since a window must not change in
-    // size to go fullscreen
-    connect(actor.metaWindow, 'notify::fullscreen', () => {
-        if (actor.metaWindow) {
-            handlers.onSizeChanged(actor);
-        }
-    });
+        // Get notified about fullscreen explicitly, since a window must not change in
+        // size to go fullscreen
+        connect(actor.metaWindow, 'notify::fullscreen', () => {
+            if (actor.metaWindow) {
+                handlers.onSizeChanged(actor);
+            }
+        });
 
-    // Window focus changed.
-    connect(actor.metaWindow, 'notify::appears-focused', () => {
-        if (actor.metaWindow) {
-            handlers.onFocusChanged(actor);
-        }
-    });
+        // Window focus changed.
+        connect(actor.metaWindow, 'notify::appears-focused', () => {
+            if (actor.metaWindow) {
+                handlers.onFocusChanged(actor);
+            }
+        });
 
-    // Workspace or monitor of the window changed.
-    connect(actor.metaWindow, 'workspace-changed', () => {
-        if (actor.metaWindow) {
-            handlers.onFocusChanged(actor);
-        }
-    });
+        // Workspace or monitor of the window changed.
+        connect(actor.metaWindow, 'workspace-changed', () => {
+            if (actor.metaWindow) {
+                handlers.onFocusChanged(actor);
+            }
+        });
+
+        actor.rwcSignalsConnected = true;
+        actor.rwcSignalTexture = texture;
+    }
 
     handlers.onAddEffect(actor);
 }
@@ -202,7 +218,17 @@ function applyEffectTo(actor: RoundedWindowActor) {
  */
 function removeEffectFrom(actor: RoundedWindowActor) {
     disconnectAll(actor);
-    disconnectAll(actor.metaWindow);
+    delete actor.rwcSignalsConnected;
+    delete actor.rwcWaitingForFirstChild;
+
+    if (actor.metaWindow) {
+        disconnectAll(actor.metaWindow);
+    }
+
+    if (actor.rwcSignalTexture) {
+        disconnectAll(actor.rwcSignalTexture);
+        delete actor.rwcSignalTexture;
+    }
 
     const texture = actor.get_texture();
     if (texture) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -55,4 +55,7 @@ export type RoundedWindowActor = Meta.WindowActor & {
         unminimizedTimeoutId: number;
         propertyBindings: GObject.Binding[];
     };
+    rwcSignalsConnected?: boolean;
+    rwcWaitingForFirstChild?: boolean;
+    rwcSignalTexture?: GObject.Object;
 };


### PR DESCRIPTION
Avoid applying or refreshing rounded-corner effects after a window actor loses its Meta.Window during close animations. Track per-window signal hookups so repeated applyEffectTo() calls do not accumulate duplicate handlers, and retain the connected texture reference so its size-changed handler can be disconnected during cleanup even if get_texture() changes.

This targets the null-window close-animation crash reported in #127 and the fatal GNOME Shell SIGABRT reported in #131.

<!--
IMPORTANT, PLEASE READ

AI-assisted contributions are not forbidden,
but you MUST manually test the changes you submit
and make sure they are actually necessary.

If the change is mostly AI-authored, you must disclose
that in your pull request description.

Submitting a blatantly obvious AI hallucination
with no disclosure will get you blocked from this repository.
-->
